### PR TITLE
Align pkgdown with the rtichoke visual identity

### DIFF
--- a/.github/workflows/pkgdown-preview.yaml
+++ b/.github/workflows/pkgdown-preview.yaml
@@ -1,0 +1,79 @@
+name: pkgdown preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pkgdown-pages
+  cancel-in-progress: false
+
+jobs:
+  preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build pkgdown site
+        run: Rscript -e 'pkgdown::build_site(new_process = FALSE)'
+
+      - name: Publish PR preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages
+          git worktree add /tmp/gh-pages origin/gh-pages
+          rm -rf "/tmp/gh-pages/pr-preview/pr-${PR_NUMBER}"
+          mkdir -p "/tmp/gh-pages/pr-preview/pr-${PR_NUMBER}"
+          cp -a docs/. "/tmp/gh-pages/pr-preview/pr-${PR_NUMBER}/"
+          cd /tmp/gh-pages
+          git add "pr-preview/pr-${PR_NUMBER}"
+          if git diff --cached --quiet; then
+            echo "Preview is already up to date."
+            exit 0
+          fi
+          git commit -m "Deploy pkgdown preview for PR #${PR_NUMBER}"
+          git push origin HEAD:gh-pages
+
+  cleanup:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Remove PR preview
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin gh-pages
+          git worktree add /tmp/gh-pages origin/gh-pages
+          cd /tmp/gh-pages
+          if [ ! -d "pr-preview/pr-${PR_NUMBER}" ]; then
+            echo "No preview directory to remove."
+            exit 0
+          fi
+          rm -rf "pr-preview/pr-${PR_NUMBER}"
+          git add -A "pr-preview/pr-${PR_NUMBER}"
+          git commit -m "Remove pkgdown preview for PR #${PR_NUMBER}"
+          git push origin HEAD:gh-pages

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,0 +1,76 @@
+@import url("https://fonts.googleapis.com/css2?family=Commissioner:wght@400;500;600&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap");
+
+:root {
+  --rtichoke-bg: #fff7f5;
+  --rtichoke-surface: #ffffff;
+  --rtichoke-soft: #fef0ec;
+  --rtichoke-primary: #c54b29;
+  --rtichoke-accent: #ce3d15;
+  --rtichoke-border: #f0cfc3;
+  --rtichoke-text: #281d19;
+}
+
+body {
+  background: var(--rtichoke-bg);
+  color: var(--rtichoke-text);
+  font-family: "Commissioner", system-ui, sans-serif;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.navbar-brand {
+  color: var(--rtichoke-primary);
+  font-family: "Fraunces", Georgia, serif;
+  font-weight: 700;
+}
+
+a {
+  color: var(--rtichoke-accent);
+}
+
+a:hover,
+a:focus {
+  color: var(--rtichoke-primary);
+}
+
+.navbar {
+  background: rgba(255, 247, 245, 0.96) !important;
+  border-bottom: 1px solid var(--rtichoke-border);
+}
+
+.navbar .navbar-brand,
+.navbar .nav-link {
+  color: var(--rtichoke-primary) !important;
+}
+
+.navbar .nav-link:hover,
+.navbar .nav-link:focus,
+.navbar .nav-link.active {
+  color: var(--rtichoke-accent) !important;
+}
+
+pre,
+.sourceCode,
+.card,
+.callout {
+  border-color: var(--rtichoke-border) !important;
+  border-radius: 0.75rem;
+}
+
+pre,
+.sourceCode {
+  background: #fffdfc;
+}
+
+code {
+  color: #8f321b;
+}
+
+.btn-primary {
+  background-color: var(--rtichoke-primary);
+  border-color: var(--rtichoke-primary);
+}

--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Commissioner:wght@400;500;600&family=Fraunces:opsz,wght@9..144,600;9..144,700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Commissioner:wght@400;500;600&family=Fraunces:opsz,wght@9..144,300&display=swap");
 
 :root {
   --rtichoke-bg: #fff7f5;
@@ -14,6 +14,7 @@ body {
   background: var(--rtichoke-bg);
   color: var(--rtichoke-text);
   font-family: "Commissioner", system-ui, sans-serif;
+  font-weight: 400;
 }
 
 h1,
@@ -23,9 +24,10 @@ h4,
 h5,
 h6,
 .navbar-brand {
-  color: var(--rtichoke-primary);
+  color: var(--rtichoke-accent);
   font-family: "Fraunces", Georgia, serif;
-  font-weight: 700;
+  font-weight: 300;
+  letter-spacing: -0.015em;
 }
 
 a {


### PR DESCRIPTION
## What changed

Adds a small `pkgdown/extra.css` layer that brings pkgdown closer to the visual language already used by rtichoke Great Docs and the blog: shared typography, warm rtichoke palette, navbar treatment, links, code blocks, and primary buttons.

## Why

The R and Python documentation should feel like members of the same rtichoke family without forcing pkgdown and Great Docs into identical layouts.

## Scope

This deliberately preserves pkgdown's native information architecture and Bootstrap layout. It is only a visual alignment pass.