### PR TITLE
Validate binary outcomes in performance builders

### DIFF
--- a/R/prepare_performance_data.R
+++ b/R/prepare_performance_data.R
@@ -104,7 +104,7 @@ prepare_performance_data <- function(probs,
   . <- probability_threshold <- NULL
 
   check_probs_input(probs)
-  # check_real_input(reals)
+  check_real_input(reals)
 
   match.arg(stratified_by, c("probability_threshold", "ppcr"))
 

--- a/tests/testthat/test-check_inputs.R
+++ b/tests/testthat/test-check_inputs.R
@@ -54,6 +54,21 @@ test_that("real must be 0 or 1", {
 })
 
 
+test_that("public performance builders reject non-binary outcomes", {
+  probs <- list(c(example_dat$estimated_probabilities, 0.5))
+  invalid_reals <- list(c(example_dat$outcome, 0.5))
+
+  expect_error(
+    prepare_performance_data(probs = probs, reals = invalid_reals),
+    "Outcomes are out of the range"
+  )
+  expect_error(
+    create_roc_curve(probs = probs, reals = invalid_reals),
+    "Outcomes are out of the range"
+  )
+})
+
+
 test_that("public curve builders reject out-of-range probabilities", {
   invalid_probs <- list(c(example_dat$estimated_probabilities, -0.1))
   reals <- list(c(example_dat$outcome, 1))


### PR DESCRIPTION
## Summary
- re-enable the existing `check_real_input(reals)` validation at the shared `prepare_performance_data()` entry point
- add public regression tests showing that non-binary outcomes are rejected by `prepare_performance_data()` and `create_roc_curve()`

## Classification
Correctness / validation bug. The helper already exists and documents binary outcomes, but the production validation call was commented out, allowing non-binary outcomes to reach binary-classification calculations.

## Scope
Very small behavior fix. No statistical formulas, return schemas, public signatures, documentation structure, or dependencies are changed.

## Follow-up
Calibration has a separate construction path with its own commented-out outcome validation and is intentionally not bundled into this PR. That should be handled separately after confirming the same intended contract there.