### PR TITLE
Validate binary outcomes in calibration builders

### DIFF
--- a/R/calibration.R
+++ b/R/calibration.R
@@ -97,7 +97,7 @@ create_calibration_curve <- function(probs,
                                      type = "discrete",
                                      size = NULL) {
   check_probs_input(probs)
-  # check_real_input(real)
+  check_real_input(reals)
 
   calibration_curve_list <- create_calibration_curve_list(
     probs = probs,
@@ -217,7 +217,7 @@ create_calibration_curve_list <- function(probs,
                                           ),
                                           size = NULL) {
   check_probs_input(probs)
-  # check_real_input(real)
+  check_real_input(reals)
 
   if (is.null(names(probs))) {
     names(probs) <- "model"

--- a/tests/testthat/test-calibration.R
+++ b/tests/testthat/test-calibration.R
@@ -5,7 +5,7 @@ test_that("test deciles dat", {
   )
 
   expect_identical(deciles_dat$quintile, 1:10)
-  expect_identical(names(deciles_dat), 
+  expect_identical(names(deciles_dat),
                    c("quintile", "y", "x", "sum_reals", "total_obs"))
 })
 
@@ -21,29 +21,43 @@ test_that("limits of calibration curve", {
 })
 
 
-test_that("checking probs and real inputs", {
+test_that("calibration validates probability and outcome inputs", {
   expect_error(
     create_calibration_curve(
       probs = c(example_dat$estimated_probabilities, -0.2),
-      real = c(example_dat$outcome, 1)
-    )
+      reals = c(example_dat$outcome, 1)
+    ),
+    "Estimated Probabilities are out of the range"
   )
 
-  # expect_error(
-  #   create_calibration_curve(
-  #     probs = list(
-  #       "train" = example_dat %>%
-  #         dplyr::filter(type_of_set == "train") %>%
-  #         dplyr::pull(estimated_probabilities),
-  #       "test" = c(example_dat %>% dplyr::filter(type_of_set == "test") %>%
-  #         dplyr::pull(estimated_probabilities), 0.3)
-  #     ),
-  #     real = list(
-  #       "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
-  #         dplyr::pull(outcome),
-  #       "test" = c(example_dat %>% dplyr::filter(type_of_set == "test") %>%
-  #         dplyr::pull(outcome), 2)
-  #     )
-  #   )
-  # )
+  expect_error(
+    create_calibration_curve(
+      probs = list(example_dat$estimated_probabilities),
+      reals = list(replace(example_dat$outcome, 1, 2))
+    ),
+    "Outcomes are out of the range"
+  )
+
+  expect_error(
+    create_calibration_curve_list(
+      probs = list(
+        train = example_dat %>%
+          dplyr::filter(type_of_set == "train") %>%
+          dplyr::pull(estimated_probabilities),
+        test = example_dat %>%
+          dplyr::filter(type_of_set == "test") %>%
+          dplyr::pull(estimated_probabilities)
+      ),
+      reals = list(
+        train = example_dat %>%
+          dplyr::filter(type_of_set == "train") %>%
+          dplyr::pull(outcome),
+        test = example_dat %>%
+          dplyr::filter(type_of_set == "test") %>%
+          dplyr::pull(outcome) %>%
+          replace(1, 2)
+      )
+    ),
+    "Outcomes are out of the range"
+  )
 })


### PR DESCRIPTION
## Summary
- restore `check_real_input(reals)` in both calibration entry points
- add regression coverage for invalid binary outcomes with valid probabilities
- cover both ordinary and several-population calibration inputs

## Scope
Correctness-only fix. No statistical calculations, output schemas, plotting behavior, or public API are changed for valid inputs.

## Rationale
Calibration was the remaining binary-outcome builder with its existing outcome validator commented out, allowing non-binary outcomes to proceed into calibration calculations.