### PR TITLE
Adopt Air and lintr for incremental style checks

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,0 +1,60 @@
+on:
+  pull_request:
+
+name: style
+
+permissions: read-all
+
+jobs:
+  style:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - uses: posit-dev/setup-air@v1
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: |
+            any::lintr
+            any::pkgload
+          needs: check
+
+      - name: Find changed R files
+        id: changed-r-files
+        shell: bash
+        run: |
+          git diff --name-only --diff-filter=ACMR \
+            "${{ github.event.pull_request.base.sha }}" HEAD \
+            -- '*.R' > changed-r-files.txt
+
+          if [[ -s changed-r-files.txt ]]; then
+            echo "has-files=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has-files=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check Air formatting
+        if: steps.changed-r-files.outputs.has-files == 'true'
+        shell: bash
+        run: |
+          while IFS= read -r file; do
+            air format "$file" --check
+          done < changed-r-files.txt
+
+      - name: Lint changed R files
+        if: steps.changed-r-files.outputs.has-files == 'true'
+        shell: Rscript {0}
+        run: |
+          pkgload::load_all(export_all = FALSE, helpers = FALSE, quiet = TRUE)
+          files <- readLines("changed-r-files.txt")
+          lints <- unlist(lapply(files, lintr::lint), recursive = FALSE)
+          print(lints)
+          if (length(lints) > 0) {
+            quit(status = 1)
+          }

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,2 @@
+linters: linters_with_defaults()
+encoding: "UTF-8"

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,12 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+assignment-style = "arrow"
+exclude = []
+default-exclude = true
+skip = []
+table = []
+default-table = true


### PR DESCRIPTION
## Summary
- add an explicit project-level `air.toml` using Air's current defaults
- add a tidyverse-oriented `.lintr` configuration
- add one fast PR-only style job that checks only changed `.R` files with Air and lintr

## Why incremental
The existing package has substantial legacy formatting. This deliberately does **not** run Air across the whole repository or reformat statistical code. Instead, files converge toward modern style when they are edited, avoiding a large behavior-adjacent formatting diff.

## CI design
- single Ubuntu job, separate from the full R CMD check matrix
- uses `posit-dev/setup-air@v1`
- uses current `r-lib/actions` setup actions
- loads the package before linting so package-aware linters have the right context
- skips formatting/lint work when a PR changes no `.R` files

## Scope
Developer tooling only. No package runtime dependencies, statistical calculations, public API, documentation outputs, or generated package files are changed.