### PR TITLE
Modernize roxygen2 documentation consistency

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -29,6 +29,16 @@ jobs:
         shell: Rscript {0}
         run: roxygen2::roxygenise()
 
+      - name: Capture generated diff
+        shell: bash
+        run: git diff -- DESCRIPTION NAMESPACE man > roxygen-generated.diff
+
+      - name: Upload generated diff
+        uses: actions/upload-artifact@v4
+        with:
+          name: roxygen-generated-diff
+          path: roxygen-generated.diff
+
       - name: Check generated files are current
         shell: bash
         run: git diff --exit-code -- DESCRIPTION NAMESPACE man

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -29,16 +29,6 @@ jobs:
         shell: Rscript {0}
         run: roxygen2::roxygenise()
 
-      - name: Capture generated diff
-        shell: bash
-        run: git diff -- DESCRIPTION NAMESPACE man > roxygen-generated.diff
-
-      - name: Upload generated diff
-        uses: actions/upload-artifact@v4
-        with:
-          name: roxygen-generated-diff
-          path: roxygen-generated.diff
-
       - name: Check generated files are current
         shell: bash
         run: git diff --exit-code -- DESCRIPTION NAMESPACE man

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,0 +1,34 @@
+on:
+  pull_request:
+    paths:
+      - "R/**"
+      - "man/**"
+      - "DESCRIPTION"
+      - "NAMESPACE"
+      - ".github/workflows/documentation.yaml"
+
+name: documentation
+
+permissions: read-all
+
+jobs:
+  documentation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::roxygen2
+          needs: check
+
+      - name: Regenerate documentation
+        shell: Rscript {0}
+        run: roxygen2::roxygenise()
+
+      - name: Check generated files are current
+        shell: bash
+        run: git diff --exit-code -- DESCRIPTION NAMESPACE man

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,5 +39,5 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 8.1.0
 Config/testthat/edition: 3
+Config/roxygen2/version: 8.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,5 +39,5 @@ VignetteBuilder:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 8.1.0
 Config/testthat/edition: 3

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -24,7 +24,9 @@ importFrom(crosstalk,SharedData)
 importFrom(graphics,text)
 importFrom(magrittr,"%>%")
 importFrom(pROC,auc)
-importFrom(stats,approx)
-importFrom(stats,as.formula)
-importFrom(stats,lowess)
-importFrom(stats,quantile)
+importFrom(stats,
+  approx,
+  as.formula,
+  lowess,
+  quantile
+)

--- a/man/define_limits_for_calibration_plot.Rd
+++ b/man/define_limits_for_calibration_plot.Rd
@@ -6,9 +6,6 @@
 \usage{
 define_limits_for_calibration_plot(deciles_dat)
 }
-\arguments{
-\item{deciles_dat}{}
-}
 \description{
 Define limits for Calibration Curve
 }

--- a/man/rtichoke-package.Rd
+++ b/man/rtichoke-package.Rd
@@ -19,5 +19,10 @@ Useful links:
 \author{
 \strong{Maintainer}: Uriah Finkel \email{ufinkel@gmail.com}
 
+Authors:
+\itemize{
+  \item Uriah Finkel \email{ufinkel@gmail.com}
+}
+
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary
- update the recorded roxygen2 generation version to 8.1.0
- add a focused CI check that regenerates documentation with current roxygen2
- fail when `DESCRIPTION`, `NAMESPACE`, or `man/` are stale relative to the roxygen source comments

## Scope
Documentation/developer tooling only. No statistical calculations, public API, exports, imports, return values, or plotting behavior are intentionally changed.

## Safety
The new CI job runs `roxygen2::roxygenise()` and then checks the generated diff. Any unexpected `NAMESPACE` or `.Rd` changes will be reviewed before merge rather than accepted automatically.