### PR TITLE
Modernize pkgdown infrastructure

### DIFF
--- a/.github/workflows/pkgdown-preview.yaml
+++ b/.github/workflows/pkgdown-preview.yaml
@@ -18,7 +18,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -58,7 +58,7 @@ jobs:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Remove PR preview
         env:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -7,13 +7,20 @@ on:
 
 name: pkgdown
 
+permissions:
+  contents: write
+
+concurrency:
+  group: pkgdown-pages
+  cancel-in-progress: false
+
 jobs:
   pkgdown:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Authors@R:
     person("Uriah", "Finkel", , "ufinkel@gmail.com", role = c("cre", "aut"))
 Description: Interactive visualization for model performance.
 License: MIT + file LICENSE
-URL: https://github.com/uriahf/rtichoke
+URL: https://uriahf.github.io/rtichoke/, https://github.com/uriahf/rtichoke
 BugReports: https://github.com/uriahf/rtichoke/issues
 Depends: 
     R (>= 2.10)

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,3 @@
-url: ~
+url: https://uriahf.github.io/rtichoke/
 template:
   bootstrap: 5
-

--- a/man/rtichoke-package.Rd
+++ b/man/rtichoke-package.Rd
@@ -11,6 +11,7 @@ Interactive visualization for model performance.
 \seealso{
 Useful links:
 \itemize{
+  \item \url{https://uriahf.github.io/rtichoke/}
   \item \url{https://github.com/uriahf/rtichoke}
   \item Report bugs at \url{https://github.com/uriahf/rtichoke/issues}
 }


### PR DESCRIPTION
## Summary
- configure the canonical pkgdown URL in `_pkgdown.yml`
- advertise the documentation site in `DESCRIPTION` and regenerated package docs
- update pkgdown workflows to `actions/checkout@v6`
- add explicit write permissions and shared deployment concurrency to the main pkgdown workflow

## Scope
Documentation and CI infrastructure only. No statistical calculations, package functions, exports, imports, return values, or public API behavior are changed.

## Rationale
This brings the pkgdown setup in line with the repository's already-modernized GitHub Actions tooling and makes the documentation URL discoverable to pkgdown, package metadata consumers, and users.