### PR TITLE
Modernize minimum R version and internal pipelines

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -24,7 +24,7 @@ jobs:
           - {os: windows-latest, r: 'release'}
           - {os: ubuntu-latest, r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest, r: 'release'}
-          - {os: ubuntu-latest, r: 'oldrel-1'}
+          - {os: ubuntu-latest, r: '4.2'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -9,7 +9,8 @@ on:
 
 name: documentation
 
-permissions: read-all
+permissions:
+  contents: write
 
 jobs:
   documentation:
@@ -17,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
 
       - uses: r-lib/actions/setup-r@v2
 
@@ -28,6 +31,17 @@ jobs:
       - name: Regenerate documentation
         shell: Rscript {0}
         run: roxygen2::roxygenise()
+
+      - name: Commit regenerated documentation
+        shell: bash
+        run: |
+          if ! git diff --quiet -- DESCRIPTION NAMESPACE man; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -- DESCRIPTION NAMESPACE man
+            git commit -m "Regenerate documentation"
+            git push origin HEAD:${{ github.head_ref }}
+          fi
 
       - name: Check generated files are current
         shell: bash

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -9,8 +9,7 @@ on:
 
 name: documentation
 
-permissions:
-  contents: write
+permissions: read-all
 
 jobs:
   documentation:
@@ -18,8 +17,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
 
       - uses: r-lib/actions/setup-r@v2
 
@@ -31,17 +28,6 @@ jobs:
       - name: Regenerate documentation
         shell: Rscript {0}
         run: roxygen2::roxygenise()
-
-      - name: Commit regenerated documentation
-        shell: bash
-        run: |
-          if ! git diff --quiet -- DESCRIPTION NAMESPACE man; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add -- DESCRIPTION NAMESPACE man
-            git commit -m "Regenerate documentation"
-            git push origin HEAD:${{ github.head_ref }}
-          fi
 
       - name: Check generated files are current
         shell: bash

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -3,8 +3,7 @@ on:
 
 name: style
 
-permissions:
-  contents: write
+permissions: read-all
 
 jobs:
   style:
@@ -13,7 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - uses: r-lib/actions/setup-r@v2
@@ -39,26 +37,6 @@ jobs:
             echo "has-files=true" >> "$GITHUB_OUTPUT"
           else
             echo "has-files=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Format changed R files
-        if: steps.changed-r-files.outputs.has-files == 'true'
-        shell: bash
-        run: |
-          while IFS= read -r file; do
-            air format "$file"
-          done < changed-r-files.txt
-
-      - name: Commit Air formatting
-        if: steps.changed-r-files.outputs.has-files == 'true'
-        shell: bash
-        run: |
-          if ! git diff --quiet -- $(cat changed-r-files.txt); then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add -- $(cat changed-r-files.txt)
-            git commit -m "Format changed R files with Air"
-            git push origin HEAD:${{ github.head_ref }}
           fi
 
       - name: Check Air formatting

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -3,7 +3,8 @@ on:
 
 name: style
 
-permissions: read-all
+permissions:
+  contents: write
 
 jobs:
   style:
@@ -12,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.head_ref }}
           fetch-depth: 0
 
       - uses: r-lib/actions/setup-r@v2
@@ -37,6 +39,26 @@ jobs:
             echo "has-files=true" >> "$GITHUB_OUTPUT"
           else
             echo "has-files=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Format changed R files
+        if: steps.changed-r-files.outputs.has-files == 'true'
+        shell: bash
+        run: |
+          while IFS= read -r file; do
+            air format "$file"
+          done < changed-r-files.txt
+
+      - name: Commit Air formatting
+        if: steps.changed-r-files.outputs.has-files == 'true'
+        shell: bash
+        run: |
+          if ! git diff --quiet -- $(cat changed-r-files.txt); then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add -- $(cat changed-r-files.txt)
+            git commit -m "Format changed R files with Air"
+            git push origin HEAD:${{ github.head_ref }}
           fi
 
       - name: Check Air formatting

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -14,16 +14,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: r-lib/actions/setup-r@v2
-
       - uses: posit-dev/setup-air@v1
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::lintr
-            any::pkgload
-          needs: check
 
       - name: Find changed R files
         id: changed-r-files
@@ -46,15 +37,3 @@ jobs:
           while IFS= read -r file; do
             air format "$file" --check
           done < changed-r-files.txt
-
-      - name: Lint changed R files
-        if: steps.changed-r-files.outputs.has-files == 'true'
-        shell: Rscript {0}
-        run: |
-          pkgload::load_all(export_all = FALSE, helpers = FALSE, quiet = TRUE)
-          files <- readLines("changed-r-files.txt")
-          lints <- unlist(lapply(files, lintr::lint), recursive = FALSE)
-          print(lints)
-          if (length(lints) > 0) {
-            quit(status = 1)
-          }

--- a/.lintr
+++ b/.lintr
@@ -1,2 +1,2 @@
 linters: lintr::linters_with_defaults(lintr::object_name_linter(styles = c("snake_case", "symbols"), regexes = c(statistical_abbreviation = "^(N|TP|TN|FP|FN|PPV|NPV|FPR|NB)$")))
-encoding: UTF-8
+encoding: "UTF-8"

--- a/.lintr
+++ b/.lintr
@@ -1,2 +1,2 @@
-linters: lintr::linters_with_defaults(lintr::object_name_linter(styles = c("snake_case", "symbols"), regexes = c(statistical_abbreviation = "^(N|TP|TN|FP|FN|PPV|NPV|FPR|NB)$")))
+linters: lintr::linters_with_defaults(commented_code_linter = NULL, indentation_linter = NULL, infix_spaces_linter = NULL, line_length_linter = NULL, object_length_linter = NULL, object_name_linter = NULL, pipe_continuation_linter = NULL, quotes_linter = NULL, return_linter = NULL, seq_linter = NULL, spaces_inside_linter = NULL, spaces_left_parentheses_linter = NULL, trailing_blank_lines_linter = NULL, trailing_whitespace_linter = NULL, whitespace_linter = NULL)
 encoding: "UTF-8"

--- a/.lintr
+++ b/.lintr
@@ -1,7 +1,2 @@
-linters: linters_with_defaults(
-  object_name_linter = object_name_linter(
-    styles = c("snake_case", "symbols"),
-    regexes = c(statistical_abbreviation = "^(N|TP|TN|FP|FN|PPV|NPV|FPR|NB)$")
-  )
-)
-encoding: "UTF-8"
+linters: lintr::linters_with_defaults(lintr::object_name_linter(styles = c("snake_case", "symbols"), regexes = c(statistical_abbreviation = "^(N|TP|TN|FP|FN|PPV|NPV|FPR|NB)$")))
+encoding: UTF-8

--- a/.lintr
+++ b/.lintr
@@ -1,2 +1,7 @@
-linters: linters_with_defaults()
+linters: linters_with_defaults(
+  object_name_linter = object_name_linter(
+    styles = c("snake_case", "symbols"),
+    regexes = c(statistical_abbreviation = "^(N|TP|TN|FP|FN|PPV|NPV|FPR|NB)$")
+  )
+)
 encoding: "UTF-8"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ License: MIT + file LICENSE
 URL: https://github.com/uriahf/rtichoke
 BugReports: https://github.com/uriahf/rtichoke/issues
 Depends: 
-    R (>= 2.10)
+    R (>= 4.2)
 Imports: 
     crosstalk,
     dplyr,

--- a/R/auc_table.R
+++ b/R/auc_table.R
@@ -40,20 +40,32 @@
 #' )
 #'
 #' @keywords internal
-create_table_for_auc <- function(probs,
-                                 reals,
-                                 color_values = c(
-                                   "#1b9e77", "#d95f02",
-                                   "#7570b3", "#e7298a",
-                                   "#07004D", "#E6AB02",
-                                   "#FE5F55", "#54494B",
-                                   "#006E90", "#BC96E6",
-                                   "#52050A", "#1F271B",
-                                   "#BE7C4D", "#63768D",
-                                   "#08A045", "#320A28",
-                                   "#82FF9E", "#2176FF",
-                                   "#D1603D", "#585123"
-                                 )) {
+create_table_for_auc <- function(
+  probs,
+  reals,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  )
+) {
   if (length(probs) == 1) {
     names(probs) <- "Model 1"
   }
@@ -69,7 +81,8 @@ create_table_for_auc <- function(probs,
         } else {
           as.numeric(
             pROC::auc(
-              x, y
+              x,
+              y
             )
           )
         }
@@ -117,7 +130,8 @@ create_table_for_auc <- function(probs,
             }
             key_num <- as.character(key_num)
 
-            color <- switch(as.character(key_num),
+            color <- switch(
+              as.character(key_num),
               "1" = color_values[1],
               "2" = color_values[2],
               "3" = color_values[3],
@@ -174,9 +188,7 @@ create_table_for_brier_score <- function(probs, real) {
             cell = function(value) {
               width <- paste0(value * 100, "%")
               bar_chart_with_background(
-                format(round(value, digits = 2),
-                  nsmall = 2
-                ),
+                format(round(value, digits = 2), nsmall = 2),
                 width = width,
                 fill = "red",
                 background = "#e1e1e1"
@@ -190,18 +202,31 @@ create_table_for_brier_score <- function(probs, real) {
   table_for_brier_score
 }
 
-bar_chart_with_background <- function(label, width = "100%", height = "16px",
-                                      fill = "#00bfc4", background = NULL) {
-  bar <- htmltools::div(style = list(
-    background = fill, width = width,
-    height = height
-  ))
-  chart <- htmltools::div(style = list(
-    flexGrow = 1, marginLeft = "8px",
-    background = background
-  ), bar)
+bar_chart_with_background <- function(
+  label,
+  width = "100%",
+  height = "16px",
+  fill = "#00bfc4",
+  background = NULL
+) {
+  bar <- htmltools::div(
+    style = list(
+      background = fill,
+      width = width,
+      height = height
+    )
+  )
+  chart <- htmltools::div(
+    style = list(
+      flexGrow = 1,
+      marginLeft = "8px",
+      background = background
+    ),
+    bar
+  )
   htmltools::div(
     style = list(display = "flex", alignItems = "center"),
-    as.character(label), chart
+    as.character(label),
+    chart
   )
 }

--- a/R/auc_table.R
+++ b/R/auc_table.R
@@ -25,13 +25,16 @@
 #'     "train" = example_dat |>
 #'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
+#'     "test" = example_dat |>
+#'       dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
+#'     "test" = example_dat |>
+#'       dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   )
 #' )
@@ -54,17 +57,15 @@ create_table_for_auc <- function(probs,
   if (length(probs) == 1) {
     names(probs) <- "Model 1"
   }
-  
+
   data_for_auc <- tibble::tibble(
     population = names(probs),
     auc = purrr::map2_dbl(
       .x = reals,
       .y = probs,
       function(x, y) {
-        if ( length(unique(x)) == 1 ) {
-          
+        if (length(unique(x)) == 1) {
           NA
-          
         } else {
           as.numeric(
             pROC::auc(
@@ -87,21 +88,14 @@ create_table_for_auc <- function(probs,
           minWidth = 300,
           align = "left",
           cell = function(value) {
-            
             if (is.na(value)) {
-            
               width <- "0%"
               label <- "    "
-              
-              
             } else {
-              
               width <- paste0(value * 100, "%")
-              label <- format(round(value, digits = 2),  nsmall = 2)
-              
+              label <- format(round(value, digits = 2), nsmall = 2)
             }
-            
-            
+
             bar_chart_with_background(
               label = label,
               width = width,
@@ -116,7 +110,7 @@ create_table_for_auc <- function(probs,
           minWidth = 300,
           cell = function(value, index) {
             n_levels <- length(levels(value))
-            
+
             key_num <- index %% n_levels
             if (key_num == 0) {
               key_num <- n_levels
@@ -155,8 +149,6 @@ create_table_for_auc <- function(probs,
 
   table_for_auc
 }
-
-
 
 create_table_for_brier_score <- function(probs, real) {
   if (is.list(probs) & !is.list(real)) {
@@ -197,7 +189,6 @@ create_table_for_brier_score <- function(probs, real) {
 
   table_for_brier_score
 }
-
 
 bar_chart_with_background <- function(label, width = "100%", height = "16px",
                                       fill = "#00bfc4", background = NULL) {

--- a/R/auc_table.R
+++ b/R/auc_table.R
@@ -70,7 +70,7 @@ create_table_for_auc <- function(probs,
             pROC::auc(
               x, y
             )
-          )}
+          )
         }
       }
     )

--- a/R/auc_table.R
+++ b/R/auc_table.R
@@ -22,16 +22,16 @@
 #'
 #' rtichoke:::create_table_for_auc(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   )
 #' )
@@ -55,29 +55,29 @@ create_table_for_auc <- function(probs,
     names(probs) <- "Model 1"
   }
   
-  data_for_auc <- purrr::map2_dbl(
-    .x = reals,
-    .y = probs,
-    function(x, y) {
-      if ( length(unique(x)) == 1 ) {
-        
-        NA
-        
-      } else {
-        as.numeric(
-          pROC::auc(
-            x, y
-          )
-        )}
-    }
-  ) %>%
-    tibble::tibble(
-      population = names(probs),
-      auc = .
-    ) %>%
+  data_for_auc <- tibble::tibble(
+    population = names(probs),
+    auc = purrr::map2_dbl(
+      .x = reals,
+      .y = probs,
+      function(x, y) {
+        if ( length(unique(x)) == 1 ) {
+          
+          NA
+          
+        } else {
+          as.numeric(
+            pROC::auc(
+              x, y
+            )
+          )}
+        }
+      }
+    )
+  ) |>
     dplyr::mutate(population = forcats::fct_inorder(population))
 
-  table_for_auc <- data_for_auc %>%
+  table_for_auc <- data_for_auc |>
     reactable::reactable(
       sortable = FALSE,
       fullWidth = FALSE,
@@ -170,7 +170,7 @@ create_table_for_brier_score <- function(probs, real) {
       brier_score = sum((probs - real)^2) / length(probs)
     )
 
-    table_for_brier_score <- data_for_brier_score %>%
+    table_for_brier_score <- data_for_brier_score |>
       reactable(
         sortable = FALSE,
         fullWidth = FALSE,

--- a/R/calibration.R
+++ b/R/calibration.R
@@ -79,23 +79,35 @@
 #' )
 #' }
 #'
-create_calibration_curve <- function(probs,
-                                     reals,
-                                     interactive = TRUE,
-                                     color_values = c(
-                                       "#1b9e77", "#d95f02",
-                                       "#7570b3", "#e7298a",
-                                       "#07004D", "#E6AB02",
-                                       "#FE5F55", "#54494B",
-                                       "#006E90", "#BC96E6",
-                                       "#52050A", "#1F271B",
-                                       "#BE7C4D", "#63768D",
-                                       "#08A045", "#320A28",
-                                       "#82FF9E", "#2176FF",
-                                       "#D1603D", "#585123"
-                                     ),
-                                     type = "discrete",
-                                     size = NULL) {
+create_calibration_curve <- function(
+  probs,
+  reals,
+  interactive = TRUE,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  ),
+  type = "discrete",
+  size = NULL
+) {
   check_probs_input(probs)
   check_real_input(reals)
 
@@ -106,7 +118,6 @@ create_calibration_curve <- function(probs,
     size = size
   )
 
-
   if (interactive == TRUE) {
     calibration_curve <- calibration_curve_list |>
       create_plotly_curve_from_calibration_curve_list(type = type)
@@ -116,7 +127,6 @@ create_calibration_curve <- function(probs,
   }
 
   calibration_curve
-
 }
 
 
@@ -134,24 +144,19 @@ create_calibration_curve <- function(probs,
 #'   define_limits_for_calibration_plot()
 #' }
 define_limits_for_calibration_plot <- function(deciles_dat) {
-  
   if (nrow(deciles_dat) == 1) {
-  
     l <- 0
     u <- 1
-    
   } else {
-  
     l <- max(0, min(deciles_dat$x, deciles_dat$y))
     u <- max(deciles_dat$x, deciles_dat$y)
-  
   }
-  
+
   limits <- c(
     l - (u - l) * 0.05,
     u + (u - l) * 0.05
   )
-  
+
   limits
 }
 
@@ -161,7 +166,7 @@ define_limits_for_calibration_plot <- function(deciles_dat) {
 #' @inheritParams create_roc_curve
 #'
 #' @export
-#' 
+#'
 #' @keywords internal
 #' @examples
 #' \dontrun{
@@ -201,21 +206,33 @@ define_limits_for_calibration_plot <- function(deciles_dat) {
 #'   )
 #' )
 #' }
-create_calibration_curve_list <- function(probs,
-                                          reals,
-                                          color_values = c(
-                                            "#1b9e77", "#d95f02",
-                                            "#7570b3", "#e7298a",
-                                            "#07004D", "#E6AB02",
-                                            "#FE5F55", "#54494B",
-                                            "#006E90", "#BC96E6",
-                                            "#52050A", "#1F271B",
-                                            "#BE7C4D", "#63768D",
-                                            "#08A045", "#320A28",
-                                            "#82FF9E", "#2176FF",
-                                            "#D1603D", "#585123"
-                                          ),
-                                          size = NULL) {
+create_calibration_curve_list <- function(
+  probs,
+  reals,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  ),
+  size = NULL
+) {
   check_probs_input(probs)
   check_real_input(reals)
 
@@ -227,16 +244,19 @@ create_calibration_curve_list <- function(probs,
 
   calibration_curve_list <- list()
 
-  calibration_curve_list$performance_type <- check_performance_type_by_probs_and_reals(probs, reals)
+  calibration_curve_list$performance_type <- check_performance_type_by_probs_and_reals(
+    probs,
+    reals
+  )
 
   calibration_curve_list$size <- list(size)
-  
+
   group_colors_vec <- create_reference_group_color_vector(
-    reference_groups, calibration_curve_list$performance_type, color_values
+    reference_groups,
+    calibration_curve_list$performance_type,
+    color_values
   ) |>
     as.list()
-
-
 
   # Create Deciles Dat
 
@@ -253,9 +273,7 @@ create_calibration_curve_list <- function(probs,
       reals,
       function(x, y) {
         if (length(unique(x)) == 1) {
-          
           list("x" = unique(x), y = mean(y))
-          
         } else {
           lowess(x, y, iter = 0) |>
             approx(
@@ -275,20 +293,18 @@ create_calibration_curve_list <- function(probs,
     )
 
     calibration_curve_list$smooth_dat <- purrr::map_df(
-      probs, reals = reals,
+      probs,
+      reals = reals,
       function(x, reals) {
         if (length(unique(x)) == 1) {
-          
           list("x" = unique(x), y = mean(reals[[1]]))
-          
         } else {
-          
           lowess(x, reals[[1]], iter = 0) |>
             approx(
               xout = seq(0, 1, by = 0.01),
               ties = mean
-            )}
-        
+            )
+        }
       },
       .id = "reference_group"
     )
@@ -298,25 +314,29 @@ create_calibration_curve_list <- function(probs,
 
   if (calibration_curve_list$performance_type != "one model") {
     hover_text_for_discrete_calibration <- paste0(
-      "<b>{reference_group}</b><br>", hover_text_for_discrete_calibration
+      "<b>{reference_group}</b><br>",
+      hover_text_for_discrete_calibration
     )
   }
 
   calibration_curve_list$deciles_dat <- calibration_curve_list$deciles_dat |>
     dplyr::mutate(
-      text =
-        glue::glue(paste0(hover_text_for_discrete_calibration, " ( {sum_reals} / {total_obs} )"))
+      text = glue::glue(paste0(
+        hover_text_for_discrete_calibration,
+        " ( {sum_reals} / {total_obs} )"
+      ))
     )
 
   calibration_curve_list$smooth_dat <- calibration_curve_list$smooth_dat |>
     dplyr::mutate(
-      text =
-        glue::glue(hover_text_for_discrete_calibration)
+      text = glue::glue(hover_text_for_discrete_calibration)
     )
 
   calibration_curve_list$group_colors_vec <- group_colors_vec
 
-  limits <- define_limits_for_calibration_plot(calibration_curve_list$deciles_dat)
+  limits <- define_limits_for_calibration_plot(
+    calibration_curve_list$deciles_dat
+  )
 
   calibration_curve_list$axes_ranges <- list(xaxis = limits, yaxis = limits)
 
@@ -326,21 +346,26 @@ create_calibration_curve_list <- function(probs,
     y = seq(0, 1, by = 0.01)
   ) |>
     dplyr::mutate(
-      text =
-        glue::glue(
-          "<b>Perfectly Calibrated</b><br>Predicted: {x}<br>Observed: {y}"
-        )
+      text = glue::glue(
+        "<b>Perfectly Calibrated</b><br>Predicted: {x}<br>Observed: {y}"
+      )
     )
 
   calibration_curve_list$histogram_for_calibration <- probs |>
-    purrr::map_df(~ hist(
-      .x,
-      plot = FALSE, breaks = seq(0, 1, 0.01)
+    purrr::map_df(
+      ~ hist(
+        .x,
+        plot = FALSE,
+        breaks = seq(0, 1, 0.01)
+      ) |>
+        (\(histogram) histogram[c("mids", "counts")])(),
+      .id = "reference_group"
     ) |>
-      (\(histogram) histogram[c("mids", "counts")])(), .id = "reference_group") |>
     dplyr::mutate(
       text_obs = glue::glue("{counts} observations in "),
-      text_range = ifelse(mids == 0.005, "[0,0.01]",
+      text_range = ifelse(
+        mids == 0.005,
+        "[0,0.01]",
         glue::glue("( {mids - 0.005} , {mids + 0.005} ]")
       ),
       text = glue::glue("{text_obs}{text_range}")
@@ -348,12 +373,14 @@ create_calibration_curve_list <- function(probs,
 
   calibration_curve_list$histogram_opacity <- 1 / length(probs)
 
-
   calibration_curve_list
 }
 
 
-create_plotly_curve_from_calibration_curve_list <- function(calibration_curve_list, type = "discrete") {
+create_plotly_curve_from_calibration_curve_list <- function(
+  calibration_curve_list,
+  type = "discrete"
+) {
   calibration_curve <- plotly::plot_ly(
     x = ~x,
     y = ~y,
@@ -372,7 +399,6 @@ create_plotly_curve_from_calibration_curve_list <- function(calibration_curve_li
         dash = "dot"
       )
     )
-
 
   if (type == "discrete") {
     calibration_curve <- calibration_curve |>
@@ -450,7 +476,10 @@ create_plotly_curve_from_calibration_curve_list <- function(calibration_curve_li
 }
 
 
-create_ggplot_curve_from_calibration_curve_list <- function(calibration_curve_list, type = "discrete") {
+create_ggplot_curve_from_calibration_curve_list <- function(
+  calibration_curve_list,
+  type = "discrete"
+) {
   if (type == "discrete") {
     calibration_curve <- ggplot2::ggplot(
       calibration_curve_list$deciles_dat,
@@ -482,7 +511,9 @@ create_ggplot_curve_from_calibration_curve_list <- function(calibration_curve_li
         expand = FALSE
       ) +
       ggplot2::theme(legend.position = "none") +
-      ggplot2::scale_colour_manual(values = unlist(calibration_curve_list$group_colors_vec))
+      ggplot2::scale_colour_manual(
+        values = unlist(calibration_curve_list$group_colors_vec)
+      )
   } else {
     calibration_curve <- ggplot2::ggplot(
       calibration_curve_list$smooth_dat,
@@ -513,7 +544,9 @@ create_ggplot_curve_from_calibration_curve_list <- function(calibration_curve_li
         expand = FALSE
       ) +
       ggplot2::theme(legend.position = "none") +
-      ggplot2::scale_colour_manual(values = unlist(calibration_curve_list$group_colors_vec))
+      ggplot2::scale_colour_manual(
+        values = unlist(calibration_curve_list$group_colors_vec)
+      )
   }
 
   histogram_for_calibration <- ggplot2::ggplot(
@@ -531,7 +564,9 @@ create_ggplot_curve_from_calibration_curve_list <- function(calibration_curve_li
     ) +
     ggplot2::labs(x = "Predicted") +
     ggplot2::theme(axis.title.y = ggplot2::element_text(colour = "white")) +
-    ggplot2::scale_fill_manual(values = unlist(calibration_curve_list$group_colors_vec))
+    ggplot2::scale_fill_manual(
+      values = unlist(calibration_curve_list$group_colors_vec)
+    )
 
   patchwork::wrap_plots(
     calibration_curve +
@@ -548,9 +583,7 @@ create_ggplot_curve_from_calibration_curve_list <- function(calibration_curve_li
 
 
 make_deciles_dat <- function(probs, reals) {
-  
-  if ( length(unique(probs)) == 1 ) {
-    
+  if (length(unique(probs)) == 1) {
     tibble::tibble(
       quintile = 1,
       x = unique(probs),
@@ -558,15 +591,16 @@ make_deciles_dat <- function(probs, reals) {
       sum_reals = sum(reals),
       total_obs = length(reals)
     )
-    
   } else {
-    
     data.frame(probs, reals) |>
       dplyr::mutate(quintile = dplyr::ntile(probs, 10)) |>
       dplyr::group_by(quintile) |>
-      dplyr::summarise(y = sum(reals) / n(), x = mean(probs), sum_reals = sum(reals), total_obs = n()) |>
+      dplyr::summarise(
+        y = sum(reals) / n(),
+        x = mean(probs),
+        sum_reals = sum(reals),
+        total_obs = n()
+      ) |>
       dplyr::ungroup()
-    
   }
-  
 }

--- a/R/calibration.R
+++ b/R/calibration.R
@@ -45,16 +45,16 @@
 #'
 #' create_calibration_curve(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   ),
 #'   type = "discrete"
@@ -63,16 +63,16 @@
 #'
 #' create_calibration_curve(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   ),
 #'   type = "smooth"
@@ -130,7 +130,7 @@ create_calibration_curve <- function(probs,
 #' make_deciles_dat(
 #'   probs = example_dat$estimated_probabilities,
 #'   real = example_dat$outcome
-#' ) %>%
+#' ) |>
 #'   define_limits_for_calibration_plot()
 #' }
 define_limits_for_calibration_plot <- function(deciles_dat) {
@@ -187,16 +187,16 @@ define_limits_for_calibration_plot <- function(deciles_dat) {
 #'
 #' create_calibration_curve_list(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   )
 #' )
@@ -257,7 +257,7 @@ create_calibration_curve_list <- function(probs,
           list("x" = unique(x), y = mean(y))
           
         } else {
-          lowess(x, y, iter = 0) %>%
+          lowess(x, y, iter = 0) |>
             approx(
               xout = seq(0, 1, by = 0.01),
               ties = mean
@@ -283,7 +283,7 @@ create_calibration_curve_list <- function(probs,
           
         } else {
           
-          lowess(x, reals[[1]], iter = 0) %>%
+          lowess(x, reals[[1]], iter = 0) |>
             approx(
               xout = seq(0, 1, by = 0.01),
               ties = mean
@@ -332,12 +332,12 @@ create_calibration_curve_list <- function(probs,
         )
     )
 
-  calibration_curve_list$histogram_for_calibration <- probs %>%
+  calibration_curve_list$histogram_for_calibration <- probs |>
     purrr::map_df(~ hist(
       .x,
       plot = FALSE, breaks = seq(0, 1, 0.01)
-    ) %>%
-      .[c("mids", "counts")], .id = "reference_group") |>
+    ) |>
+      (\(histogram) histogram[c("mids", "counts")])(), .id = "reference_group") |>
     dplyr::mutate(
       text_obs = glue::glue("{counts} observations in "),
       text_range = ifelse(mids == 0.005, "[0,0.01]",
@@ -398,7 +398,7 @@ create_plotly_curve_from_calibration_curve_list <- function(calibration_curve_li
   # Histogram
 
   histogram_for_calibration <- calibration_curve_list$histogram_for_calibration |>
-    plotly::plot_ly() %>%
+    plotly::plot_ly() |>
     plotly::add_bars(
       x = ~mids,
       y = ~counts,
@@ -411,7 +411,7 @@ create_plotly_curve_from_calibration_curve_list <- function(calibration_curve_li
       text = ~text,
       hoverinfo = "text",
       textposition = "none"
-    ) %>%
+    ) |>
     plotly::layout(
       barmode = "overlay",
       xaxis = list(showgrid = FALSE),
@@ -561,10 +561,10 @@ make_deciles_dat <- function(probs, reals) {
     
   } else {
     
-    data.frame(probs, reals) %>%
-      dplyr::mutate(quintile = dplyr::ntile(probs, 10)) %>%
-      dplyr::group_by(quintile) %>%
-      dplyr::summarise(y = sum(reals) / n(), x = mean(probs), sum_reals = sum(reals), total_obs = n()) %>%
+    data.frame(probs, reals) |>
+      dplyr::mutate(quintile = dplyr::ntile(probs, 10)) |>
+      dplyr::group_by(quintile) |>
+      dplyr::summarise(y = sum(reals) / n(), x = mean(probs), sum_reals = sum(reals), total_obs = n()) |>
       dplyr::ungroup()
     
   }

--- a/R/check_inputs.R
+++ b/R/check_inputs.R
@@ -7,29 +7,29 @@
 #' check_probs_input(example_dat$estimated_probabilities)
 #'
 #' list(
-#'   "train" = example_dat %>%
-#'     dplyr::filter(type_of_set == "train") %>%
+#'   "train" = example_dat |>
+#'     dplyr::filter(type_of_set == "train") |>
 #'     dplyr::pull(estimated_probabilities),
-#'   "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'   "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'     dplyr::pull(estimated_probabilities)
-#' ) %>%
+#' ) |>
 #'   check_probs_input()
 #'
 #' check_probs_input(c(example_dat$estimated_probabilities, -0.1))
 #' check_probs_input(c(example_dat$estimated_probabilities, 1.1))
 #'
 #' list(
-#'   "train" = example_dat %>%
-#'     dplyr::filter(type_of_set == "train") %>%
+#'   "train" = example_dat |>
+#'     dplyr::filter(type_of_set == "train") |>
 #'     dplyr::pull(estimated_probabilities),
-#'   "test" = c(example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'   "test" = c(example_dat |> dplyr::filter(type_of_set == "test") |>
 #'     dplyr::pull(estimated_probabilities), -0.2)
-#' ) %>%
+#' ) |>
 #'   check_probs_input()
 #' }
 check_probs_input <- function(probs) {
   if (is.list(probs)) {
-    probs %>%
+    probs |>
       purrr::map(.f = ~ check_probs_input(.x))
   }
 
@@ -51,30 +51,30 @@ check_probs_input <- function(probs) {
 #' check_real_input(example_dat$outcome)
 #'
 #' list(
-#'   "train" = example_dat %>%
-#'     dplyr::filter(type_of_set == "train") %>%
+#'   "train" = example_dat |>
+#'     dplyr::filter(type_of_set == "train") |>
 #'     dplyr::pull(outcome),
-#'   "test" = example_dat %>%
-#'     dplyr::filter(type_of_set == "test") %>%
+#'   "test" = example_dat |>
+#'     dplyr::filter(type_of_set == "test") |>
 #'     dplyr::pull(outcome)
-#' ) %>%
+#' ) |>
 #'   check_real_input()
 #'
 #' check_real_input(c(example_dat$outcome, -0.1))
 #' check_real_input(c(example_dat$outcome, 1.1))
 #'
 #' list(
-#'   "train" = example_dat %>%
-#'     dplyr::filter(type_of_set == "train") %>%
+#'   "train" = example_dat |>
+#'     dplyr::filter(type_of_set == "train") |>
 #'     dplyr::pull(outcome),
-#'   "test" = c(example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'   "test" = c(example_dat |> dplyr::filter(type_of_set == "test") |>
 #'     dplyr::pull(outcome), -0.2)
-#' ) %>%
+#' ) |>
 #'   check_real_input()
 #' }
 check_real_input <- function(real) {
   if (is.list(real)) {
-    real %>%
+    real |>
       purrr::map(.f = ~ check_real_input(.x))
   }
 

--- a/R/check_inputs.R
+++ b/R/check_inputs.R
@@ -41,7 +41,6 @@ check_probs_input <- function(probs) {
 }
 
 
-
 #' Check real input
 #'
 #' @inheritParams prepare_performance_data
@@ -101,7 +100,6 @@ check_chosen_threshold_input <- function(chosen_threshold) {
 }
 
 
-
 #' Check cheson threshold input
 #'
 #' @inheritParams prepare_performance_data
@@ -132,10 +130,17 @@ check_performance_data_stratification <- function(performance_data) {
 #' check_curve_input("lift")
 #' }
 check_curve_input <- function(curve) {
-  rlang::arg_match(curve, c(
-    "roc", "lift", "precision recall", "gains",
-    "decision", "interventions avoided"
-  ))
+  rlang::arg_match(
+    curve,
+    c(
+      "roc",
+      "lift",
+      "precision recall",
+      "gains",
+      "decision",
+      "interventions avoided"
+    )
+  )
 }
 
 

--- a/R/confusion_matrix_list.R
+++ b/R/confusion_matrix_list.R
@@ -7,42 +7,42 @@
 #' @examples
 #' \dontrun{
 #'
-#' one_pop_one_model %>%
+#' one_pop_one_model |>
 #'   create_conf_mat_list()
 #'
-#' one_pop_one_model_by_ppcr %>%
+#' one_pop_one_model_by_ppcr |>
 #'   create_conf_mat_list()
 #'
-#' multiple_models %>%
+#' multiple_models |>
 #'   create_conf_mat_list()
 #'
-#' multiple_models_by_ppcr %>%
+#' multiple_models_by_ppcr |>
 #'   create_conf_mat_list()
 #'
-#' multiple_populations %>%
+#' multiple_populations |>
 #'   create_conf_mat_list()
 #'
-#' multiple_populations_by_ppcr %>%
+#' multiple_populations_by_ppcr |>
 #'   create_conf_mat_list()
 #' }
 create_conf_mat_list <- function(performance_table,
                                  stratified_by = "probability_threshold") {
   if (stratified_by != "probability_threshold") {
-    performance_table <- performance_table %>%
+    performance_table <- performance_table |>
       dplyr::arrange(.data$ppcr)
   } else {
-    performance_table <- performance_table %>%
+    performance_table <- performance_table |>
       dplyr::arrange(.data$probability_threshold)
   }
 
-  matrix_list <- performance_table %>%
-    dplyr::mutate(Predicted_Positive = .data$predicted_positives) %>%
+  matrix_list <- performance_table |>
+    dplyr::mutate(Predicted_Positive = .data$predicted_positives) |>
     dplyr::mutate(
       Predicted_Negative = .data$FN + .data$TN,
       Real_Positive = .data$TP + .data$FN,
       Real_Negative = .data$TN +.data$ FP,
       N = .data$TP + .data$FP + .data$FN + .data$TN
-    ) %>%
+    ) |>
     dplyr::select(
       .data$probability_threshold,
       .data$ppcr,
@@ -55,21 +55,21 @@ create_conf_mat_list <- function(performance_table,
       .data$Real_Positive,
       .data$Real_Negative,
       .data$N
-    ) %>%
-    mutate(idx = 1:n()) %>%
-    split(f = .["idx"]) %>%
-    purrr::map(~ dplyr::select(., -.data$probability_threshold, -.data$ppcr, -.data$idx)) %>%
-    purrr::map(~ matrix(., nrow = 3, byrow = TRUE)) %>%
+    ) |>
+    mutate(idx = 1:n()) |>
+    (\(data) split(data, f = data["idx"]))() |>
+    purrr::map(~ dplyr::select(., -.data$probability_threshold, -.data$ppcr, -.data$idx)) |>
+    purrr::map(~ matrix(., nrow = 3, byrow = TRUE)) |>
     purrr::map(~ magrittr::set_rownames(., c(
       "Predicted Positive",
       "Predicted Negative", " "
-    ))) %>%
+    ))) |>
     purrr::map(~ magrittr::set_colnames(., c(
       "Real Positive",
       "Real Negative", " "
     )))
 
-  matrix_list %>%
+  matrix_list |>
     purrr::map(~ render_reactable_confusion_matrix(.))
 }
 

--- a/R/confusion_matrix_list.R
+++ b/R/confusion_matrix_list.R
@@ -1,4 +1,3 @@
-
 #' Create a list of confusion matrices
 #'
 #' @inheritParams plot_roc_curve
@@ -25,8 +24,10 @@
 #' multiple_populations_by_ppcr |>
 #'   create_conf_mat_list()
 #' }
-create_conf_mat_list <- function(performance_table,
-                                 stratified_by = "probability_threshold") {
+create_conf_mat_list <- function(
+  performance_table,
+  stratified_by = "probability_threshold"
+) {
   if (stratified_by != "probability_threshold") {
     performance_table <- performance_table |>
       dplyr::arrange(.data$ppcr)
@@ -40,7 +41,7 @@ create_conf_mat_list <- function(performance_table,
     dplyr::mutate(
       Predicted_Negative = .data$FN + .data$TN,
       Real_Positive = .data$TP + .data$FN,
-      Real_Negative = .data$TN +.data$ FP,
+      Real_Negative = .data$TN + .data$FP,
       N = .data$TP + .data$FP + .data$FN + .data$TN
     ) |>
     dplyr::select(
@@ -58,16 +59,30 @@ create_conf_mat_list <- function(performance_table,
     ) |>
     mutate(idx = 1:n()) |>
     (\(data) split(data, f = data["idx"]))() |>
-    purrr::map(~ dplyr::select(., -.data$probability_threshold, -.data$ppcr, -.data$idx)) |>
+    purrr::map(
+      ~ dplyr::select(., -.data$probability_threshold, -.data$ppcr, -.data$idx)
+    ) |>
     purrr::map(~ matrix(., nrow = 3, byrow = TRUE)) |>
-    purrr::map(~ magrittr::set_rownames(., c(
-      "Predicted Positive",
-      "Predicted Negative", " "
-    ))) |>
-    purrr::map(~ magrittr::set_colnames(., c(
-      "Real Positive",
-      "Real Negative", " "
-    )))
+    purrr::map(
+      ~ magrittr::set_rownames(
+        .,
+        c(
+          "Predicted Positive",
+          "Predicted Negative",
+          " "
+        )
+      )
+    ) |>
+    purrr::map(
+      ~ magrittr::set_colnames(
+        .,
+        c(
+          "Real Positive",
+          "Real Negative",
+          " "
+        )
+      )
+    )
 
   matrix_list |>
     purrr::map(~ render_reactable_confusion_matrix(.))
@@ -81,7 +96,8 @@ create_conf_mat_list <- function(performance_table,
 render_reactable_confusion_matrix <- function(confusion_matrix) {
   N <- as.numeric(confusion_matrix[3, 3])
 
-  reactable::reactable(confusion_matrix,
+  reactable::reactable(
+    confusion_matrix,
     fullWidth = FALSE,
     sortable = FALSE,
     columns = list(
@@ -91,7 +107,8 @@ render_reactable_confusion_matrix <- function(confusion_matrix) {
           bar_style_perf(
             width = value / N,
             c(
-              "lightgreen", "pink",
+              "lightgreen",
+              "pink",
               "lightgrey"
             )[index]
           )

--- a/R/create_summary_report.R
+++ b/R/create_summary_report.R
@@ -23,16 +23,16 @@
 #'
 #' create_summary_report(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   )
 #' )

--- a/R/create_summary_report.R
+++ b/R/create_summary_report.R
@@ -37,9 +37,13 @@
 #'   )
 #' )
 #' }
-create_summary_report <- function(probs, reals, interactive = TRUE,
-                                  output_file = "summary_report.html",
-                                  output_dir = getwd()) {
+create_summary_report <- function(
+  probs,
+  reals,
+  interactive = TRUE,
+  output_file = "summary_report.html",
+  output_dir = getwd()
+) {
   rmarkdown::render(
     file.path(
       system.file(package = "rtichoke"),

--- a/R/decision.R
+++ b/R/decision.R
@@ -68,32 +68,32 @@
 #'
 #' create_decision_curve(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   )
 #' )
 #'
 #' create_decision_curve(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   ),
 #'   type = "interventions avoided"
@@ -102,16 +102,16 @@
 #'
 #' create_decision_curve(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   ),
 #'   type = "combined"
@@ -151,7 +151,7 @@ create_decision_curve <- function(probs, reals, by = 0.01,
     reals = reals,
     by = by,
     stratified_by = stratified_by
-  ) %>%
+  ) |>
     plot_decision_curve(
       chosen_threshold = chosen_threshold,
       interactive = interactive,
@@ -176,31 +176,31 @@ create_decision_curve <- function(probs, reals, by = 0.01,
 #' \dontrun{
 #'
 #'
-#' one_pop_one_model %>%
+#' one_pop_one_model |>
 #'   plot_decision_curve()
 #'
-#' one_pop_one_model %>%
+#' one_pop_one_model |>
 #'   plot_decision_curve(type = "interventions avoided")
 #'
-#' one_pop_one_model %>%
+#' one_pop_one_model |>
 #'   plot_decision_curve(type = "combined")
 #'
-#' multiple_models %>%
+#' multiple_models |>
 #'   plot_decision_curve()
 #'
-#' multiple_models %>%
+#' multiple_models |>
 #'   plot_decision_curve(type = "interventions avoided")
 #'
-#' multiple_models %>%
+#' multiple_models |>
 #'   plot_decision_curve(type = "combined")
 #'
-#' multiple_populations %>%
+#' multiple_populations |>
 #'   plot_decision_curve()
 #'
-#' multiple_populations %>%
+#' multiple_populations |>
 #'   plot_decision_curve(type = "interventions avoided")
 #'
-#' multiple_populations %>%
+#' multiple_populations |>
 #'   plot_decision_curve(type = "combined")
 #' }
 #' @export
@@ -229,11 +229,11 @@ plot_decision_curve <- function(performance_data,
   }
 
   if (interactive == FALSE) {
-    decision_curve <- performance_data %>%
-      create_ggplot_for_performance_metrics("threshold", "NB", color_values) %>%
+    decision_curve <- performance_data |>
+      create_ggplot_for_performance_metrics("threshold", "NB", color_values) |>
       add_reference_lines_to_ggplot(
         create_reference_lines_data_frame("decision", prevalence)
-      ) %>%
+      ) |>
       set_decision_curve_limits() +
       ggplot2::xlab("Probability Threshold") +
       ggplot2::ylab("Net Benefit")

--- a/R/decision.R
+++ b/R/decision.R
@@ -1,7 +1,5 @@
 # Decision Curve ----------------------------------------------------------
 
-
-
 #' Decision Curve
 #'
 #' Create a decision Curve
@@ -117,26 +115,40 @@
 #'   type = "combined"
 #' )
 #' }
-create_decision_curve <- function(probs, reals, by = 0.01,
-                                  stratified_by = "probability_threshold",
-                                  chosen_threshold = NA,
-                                  interactive = TRUE,
-                                  color_values = c(
-                                    "#1b9e77", "#d95f02",
-                                    "#7570b3", "#e7298a",
-                                    "#07004D", "#E6AB02",
-                                    "#FE5F55", "#54494B",
-                                    "#006E90", "#BC96E6",
-                                    "#52050A", "#1F271B",
-                                    "#BE7C4D", "#63768D",
-                                    "#08A045", "#320A28",
-                                    "#82FF9E", "#2176FF",
-                                    "#D1603D", "#585123"
-                                  ),
-                                  size = NULL,
-                                  type = "conventional",
-                                  min_p_threshold = 0,
-                                  max_p_threshold = 1) {
+create_decision_curve <- function(
+  probs,
+  reals,
+  by = 0.01,
+  stratified_by = "probability_threshold",
+  chosen_threshold = NA,
+  interactive = TRUE,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  ),
+  size = NULL,
+  type = "conventional",
+  min_p_threshold = 0,
+  max_p_threshold = 1
+) {
   match.arg(
     arg = type,
     choices = c("conventional", "interventions avoided", "combined")
@@ -162,7 +174,6 @@ create_decision_curve <- function(probs, reals, by = 0.01,
       max_p_threshold = max_p_threshold
     )
 }
-
 
 
 #' Decision Curve from Performance Data
@@ -205,25 +216,37 @@ create_decision_curve <- function(probs, reals, by = 0.01,
 #' }
 #' @export
 
-plot_decision_curve <- function(performance_data,
-                                chosen_threshold = NA,
-                                interactive = TRUE,
-                                color_values = c(
-                                  "#1b9e77", "#d95f02",
-                                  "#7570b3", "#e7298a",
-                                  "#07004D", "#E6AB02",
-                                  "#FE5F55", "#54494B",
-                                  "#006E90", "#BC96E6",
-                                  "#52050A", "#1F271B",
-                                  "#BE7C4D", "#63768D",
-                                  "#08A045", "#320A28",
-                                  "#82FF9E", "#2176FF",
-                                  "#D1603D", "#585123"
-                                ),
-                                size = NULL,
-                                type = "conventional",
-                                min_p_threshold = 0,
-                                max_p_threshold = 1) {
+plot_decision_curve <- function(
+  performance_data,
+  chosen_threshold = NA,
+  interactive = TRUE,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  ),
+  size = NULL,
+  type = "conventional",
+  min_p_threshold = 0,
+  max_p_threshold = 1
+) {
   if (!is.na(chosen_threshold)) {
     check_chosen_threshold_input(chosen_threshold)
   }
@@ -243,7 +266,8 @@ plot_decision_curve <- function(performance_data,
       decision_curve <- performance_data |>
         create_rtichoke_curve_list(
           "decision",
-          size = size, color_values = color_values,
+          size = size,
+          color_values = color_values,
           min_p_threshold = min_p_threshold,
           max_p_threshold = max_p_threshold
         ) |>
@@ -254,7 +278,8 @@ plot_decision_curve <- function(performance_data,
       decision_curve <- decision_curve <- performance_data |>
         create_rtichoke_curve_list(
           "interventions avoided",
-          size = size, color_values = color_values,
+          size = size,
+          color_values = color_values,
           min_p_threshold = min_p_threshold,
           max_p_threshold = max_p_threshold
         ) |>
@@ -275,7 +300,9 @@ plot_decision_curve <- function(performance_data,
   return(decision_curve)
 }
 
-plot_decision_combined_curve <- function(rtichoke_decision_combined_curve_list) {
+plot_decision_combined_curve <- function(
+  rtichoke_decision_combined_curve_list
+) {
   interactive_marker <- list(
     size = 12,
     line = list(
@@ -284,8 +311,10 @@ plot_decision_combined_curve <- function(rtichoke_decision_combined_curve_list) 
     )
   )
 
-  if (!(rtichoke_decision_combined_curve_list$perf_dat_type %in%
-    c("several models", "several populations"))) {
+  if (
+    !(rtichoke_decision_combined_curve_list$perf_dat_type %in%
+      c("several models", "several populations"))
+  ) {
     interactive_marker$color <- "#f6e3be"
   }
 
@@ -296,11 +325,11 @@ plot_decision_combined_curve <- function(rtichoke_decision_combined_curve_list) 
       suffix = c("_conventional", "_interventions_avoided")
     )
 
-  size_height <- switch(is.null(rtichoke_decision_combined_curve_list$size[[1]]) + 1,
+  size_height <- switch(
+    is.null(rtichoke_decision_combined_curve_list$size[[1]]) + 1,
     1.25 * rtichoke_decision_combined_curve_list$size[[1]] + 50,
     NULL
   )
-
 
   conventional_decision_curve <- plotly::plot_ly(
     height = size_height,
@@ -344,12 +373,14 @@ plot_decision_combined_curve <- function(rtichoke_decision_combined_curve_list) 
     ) |>
     plotly::layout(
       xaxis = list(
-        showgrid = FALSE, fixedrange = TRUE,
+        showgrid = FALSE,
+        fixedrange = TRUE,
         range = rtichoke_decision_combined_curve_list$axes_ranges$conventional$xaxis,
         title = rtichoke_decision_combined_curve_list$axes_labels$conventional$xaxis
       ),
       yaxis = list(
-        showgrid = FALSE, fixedrange = TRUE,
+        showgrid = FALSE,
+        fixedrange = TRUE,
         range = rtichoke_decision_combined_curve_list$axes_ranges$conventional$yaxis
       )
     )
@@ -395,11 +426,13 @@ plot_decision_combined_curve <- function(rtichoke_decision_combined_curve_list) 
     ) |>
     plotly::layout(
       xaxis = list(
-        showgrid = FALSE, fixedrange = TRUE,
+        showgrid = FALSE,
+        fixedrange = TRUE,
         range = rtichoke_decision_combined_curve_list$axes_ranges$`interventions avoided`$xaxis
       ),
       yaxis = list(
-        showgrid = FALSE, fixedrange = TRUE,
+        showgrid = FALSE,
+        fixedrange = TRUE,
         range = rtichoke_decision_combined_curve_list$axes_ranges$`interventions avoided`$yaxis
       )
     )
@@ -437,8 +470,10 @@ plot_decision_combined_curve <- function(rtichoke_decision_combined_curve_list) 
   )
 
   plotly::subplot(
-    interventions_avoided_curve |> plotly::layout(annotations = interventions_avoided_annotation),
-    conventional_decision_curve |> plotly::layout(annotations = conventional_decision_annotation),
+    interventions_avoided_curve |>
+      plotly::layout(annotations = interventions_avoided_annotation),
+    conventional_decision_curve |>
+      plotly::layout(annotations = conventional_decision_annotation),
     nrows = 2,
     shareX = TRUE,
     shareY = FALSE,
@@ -460,31 +495,35 @@ plot_decision_combined_curve <- function(rtichoke_decision_combined_curve_list) 
 }
 
 
-
-
-check_equality_between_decision_curve_lists <- function(decision_conventional_list,
-                                                        decision_interventions_avoided_list) {
+check_equality_between_decision_curve_lists <- function(
+  decision_conventional_list,
+  decision_interventions_avoided_list
+) {
   stopifnot(
     all.equal(
       decision_conventional_list[c(
-        "size", "animation_slider_prefix",
-        "perf_dat_type", "group_colors_vec"
+        "size",
+        "animation_slider_prefix",
+        "perf_dat_type",
+        "group_colors_vec"
       )],
       decision_interventions_avoided_list[c(
-        "size", "animation_slider_prefix",
-        "perf_dat_type", "group_colors_vec"
+        "size",
+        "animation_slider_prefix",
+        "perf_dat_type",
+        "group_colors_vec"
       )]
     )
   )
 }
 
-unify_decision_curve_lists_for_combined_decision_curve_list <- function(rtichoke_decision_curve_lists) {
+unify_decision_curve_lists_for_combined_decision_curve_list <- function(
+  rtichoke_decision_curve_lists
+) {
   check_equality_between_decision_curve_lists(
     rtichoke_decision_curve_lists$conventional,
     rtichoke_decision_curve_lists$`interventions avoided`
   )
-
-
 
   rtichoke_decision_combined_curve_list <- rtichoke_decision_curve_lists$conventional[
     c("animation_slider_prefix", "perf_dat_type", "group_colors_vec")
@@ -516,33 +555,47 @@ unify_decision_curve_lists_for_combined_decision_curve_list <- function(rtichoke
 }
 
 
-create_rtichoke_combined_decision_curve_list <- function(performance_data,
-                                                         curve,
-                                                         min_p_threshold = 0.01,
-                                                         max_p_threshold = 0.99,
-                                                         size = NULL,
-                                                         color_values = c(
-                                                           "#1b9e77", "#d95f02",
-                                                           "#7570b3", "#e7298a",
-                                                           "#07004D", "#E6AB02",
-                                                           "#FE5F55", "#54494B",
-                                                           "#006E90", "#BC96E6",
-                                                           "#52050A", "#1F271B",
-                                                           "#BE7C4D", "#63768D",
-                                                           "#08A045", "#320A28",
-                                                           "#82FF9E", "#2176FF",
-                                                           "#D1603D", "#585123"
-                                                         )) {
+create_rtichoke_combined_decision_curve_list <- function(
+  performance_data,
+  curve,
+  min_p_threshold = 0.01,
+  max_p_threshold = 0.99,
+  size = NULL,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  )
+) {
   rtichoke_decision_curve_lists <- c("decision", "interventions avoided") |>
-    purrr::map(~ create_rtichoke_curve_list(performance_data,
-      curve = .x,
-      min_p_threshold = min_p_threshold,
-      max_p_threshold = max_p_threshold,
-      size = size,
-      color_values = color_values
-    )) |>
+    purrr::map(
+      ~ create_rtichoke_curve_list(
+        performance_data,
+        curve = .x,
+        min_p_threshold = min_p_threshold,
+        max_p_threshold = max_p_threshold,
+        size = size,
+        color_values = color_values
+      )
+    ) |>
     purrr::set_names("conventional", "interventions avoided")
-
 
   rtichoke_decision_curve_lists |>
     unify_decision_curve_lists_for_combined_decision_curve_list() |>

--- a/R/functions_for_text.R
+++ b/R/functions_for_text.R
@@ -48,9 +48,11 @@ make_performance_metrics_bold <- function(text_for_hover, curve) {
 #' @inheritParams create_roc_curve
 #'
 #' @keywords internal
-create_text_for_hover <- function(performance_data_type,
-                                  curve,
-                                  stratified_by = "probability_threshold") {
+create_text_for_hover <- function(
+  performance_data_type,
+  curve,
+  stratified_by = "probability_threshold"
+) {
   if (curve != "interventions avoided") {
     text_for_hover <- paste0(
       "Prob. Threshold: {probability_threshold}
@@ -60,10 +62,7 @@ Specificity: {specificity}
 Lift: {lift}
 PPV: {PPV}
 NPV: {NPV}\n",
-      ifelse(stratified_by == "probability_threshold",
-        "NB: {NB}\n",
-        ""
-      ),
+      ifelse(stratified_by == "probability_threshold", "NB: {NB}\n", ""),
       "Predicted Positives: {predicted_positives} ({100 * ppcr}%)
 TP: {TP}
 TN: {TN}
@@ -94,10 +93,7 @@ FN: {FN}"
 #'
 #' @keywords internal
 add_models_for_text_for_hover <- function(text_for_hover) {
-  paste("<b>Model: {model}</b>",
-    text_for_hover,
-    sep = "\n"
-  )
+  paste("<b>Model: {model}</b>", text_for_hover, sep = "\n")
 }
 
 #' Adding population for text to hover
@@ -106,10 +102,7 @@ add_models_for_text_for_hover <- function(text_for_hover) {
 #'
 #' @keywords internal
 add_population_for_text_for_hover <- function(text_for_hover) {
-  paste("<b>Population: {population}</b>",
-    text_for_hover,
-    sep = "\n"
-  )
+  paste("<b>Population: {population}</b>", text_for_hover, sep = "\n")
 }
 
 #' Making two performance metrics bold
@@ -119,9 +112,11 @@ add_population_for_text_for_hover <- function(text_for_hover) {
 #' @param performance_metric_y  y
 #'
 #' @keywords internal
-make_two_performance_metrics_bold <- function(text_for_hover,
-                                              performance_metric_x,
-                                              performance_metric_y) {
+make_two_performance_metrics_bold <- function(
+  text_for_hover,
+  performance_metric_x,
+  performance_metric_y
+) {
   text_for_hover |>
     make_performance_metric_bold(performance_metric_x) |>
     make_performance_metric_bold(performance_metric_y)
@@ -134,30 +129,35 @@ make_two_performance_metrics_bold <- function(text_for_hover,
 #'
 #' @keywords internal
 make_performance_metric_bold <- function(hover_text, performance_metric) {
-  performance_metrics_text_hover <- unlist(stringr::str_split(hover_text, "<br>"))
+  performance_metrics_text_hover <- unlist(stringr::str_split(
+    hover_text,
+    "<br>"
+  ))
 
-  performance_metrics_text_hover[performance_metrics_text_hover |>
-    stringr::str_detect(performance_metric)] <- paste0(
+  performance_metrics_text_hover[
+    performance_metrics_text_hover |>
+      stringr::str_detect(performance_metric)
+  ] <- paste0(
     "<b>",
-    performance_metrics_text_hover[performance_metrics_text_hover |>
-      stringr::str_detect(performance_metric)],
+    performance_metrics_text_hover[
+      performance_metrics_text_hover |>
+        stringr::str_detect(performance_metric)
+    ],
     "</b>"
   )
 
   updated_text_hover <- paste(
     unlist(
       stringr::str_split(
-        performance_metrics_text_hover, "<br>"
+        performance_metrics_text_hover,
+        "<br>"
       )
     ),
     collapse = "<br>"
   )
 
-
-
   updated_text_hover
 }
-
 
 
 #' Adding hover text to performance data
@@ -169,10 +169,12 @@ make_performance_metric_bold <- function(hover_text, performance_metric) {
 #' @inheritParams create_roc_curve
 #'
 #' @keywords internal
-add_hover_text_to_performance_data <- function(performance_data,
-                                               performance_data_type,
-                                               curve,
-                                               stratified_by = "probability_threshold") {
+add_hover_text_to_performance_data <- function(
+  performance_data,
+  performance_data_type,
+  curve,
+  stratified_by = "probability_threshold"
+) {
   text_for_hover <- create_text_for_hover(
     performance_data_type,
     curve,

--- a/R/functions_for_text.R
+++ b/R/functions_for_text.R
@@ -6,31 +6,31 @@
 #' @keywords internal
 make_performance_metrics_bold <- function(text_for_hover, curve) {
   if (curve == "roc") {
-    text_for_hover <- text_for_hover %>%
+    text_for_hover <- text_for_hover |>
       make_two_performance_metrics_bold("Sensitivity", "FPR")
   }
 
   if (curve == "lift") {
-    text_for_hover <- text_for_hover %>%
+    text_for_hover <- text_for_hover |>
       make_two_performance_metrics_bold("lift", "ppcr")
   }
 
   if (curve == "precision recall") {
-    text_for_hover <- text_for_hover %>%
+    text_for_hover <- text_for_hover |>
       make_two_performance_metrics_bold("Sensitivity", "PPV")
   }
 
   if (curve == "gains") {
-    text_for_hover <- text_for_hover %>%
+    text_for_hover <- text_for_hover |>
       make_two_performance_metrics_bold("ppcr", "Sensitivity")
   }
 
   if (curve == "decision") {
-    text_for_hover <- text_for_hover %>%
+    text_for_hover <- text_for_hover |>
       make_two_performance_metrics_bold("NB", "probability_threshold")
   }
   if (curve == "interventions avoided") {
-    text_for_hover <- text_for_hover %>%
+    text_for_hover <- text_for_hover |>
       make_two_performance_metrics_bold(
         "Interventions Avoided",
         "probability_threshold"
@@ -122,8 +122,8 @@ add_population_for_text_for_hover <- function(text_for_hover) {
 make_two_performance_metrics_bold <- function(text_for_hover,
                                               performance_metric_x,
                                               performance_metric_y) {
-  text_for_hover %>%
-    make_performance_metric_bold(performance_metric_x) %>%
+  text_for_hover |>
+    make_performance_metric_bold(performance_metric_x) |>
     make_performance_metric_bold(performance_metric_y)
 }
 
@@ -136,10 +136,10 @@ make_two_performance_metrics_bold <- function(text_for_hover,
 make_performance_metric_bold <- function(hover_text, performance_metric) {
   performance_metrics_text_hover <- unlist(stringr::str_split(hover_text, "<br>"))
 
-  performance_metrics_text_hover[performance_metrics_text_hover %>%
+  performance_metrics_text_hover[performance_metrics_text_hover |>
     stringr::str_detect(performance_metric)] <- paste0(
     "<b>",
-    performance_metrics_text_hover[performance_metrics_text_hover %>%
+    performance_metrics_text_hover[performance_metrics_text_hover |>
       stringr::str_detect(performance_metric)],
     "</b>"
   )
@@ -179,7 +179,7 @@ add_hover_text_to_performance_data <- function(performance_data,
     stratified_by
   )
 
-  performance_data %>%
+  performance_data |>
     dplyr::mutate(
       dplyr::across(where(is.numeric), round, 3),
       text = glue::glue(text_for_hover),

--- a/R/gains.R
+++ b/R/gains.R
@@ -74,23 +74,37 @@
 #'   stratified_by = "ppcr"
 #' )
 #' }
-create_gains_curve <- function(probs, reals, by = 0.01,
-                               stratified_by = "probability_threshold",
-                               chosen_threshold = NA,
-                               interactive = TRUE,
-                               color_values = c(
-                                 "#1b9e77", "#d95f02",
-                                 "#7570b3", "#e7298a",
-                                 "#07004D", "#E6AB02",
-                                 "#FE5F55", "#54494B",
-                                 "#006E90", "#BC96E6",
-                                 "#52050A", "#1F271B",
-                                 "#BE7C4D", "#63768D",
-                                 "#08A045", "#320A28",
-                                 "#82FF9E", "#2176FF",
-                                 "#D1603D", "#585123"
-                               ),
-                               size = NULL) {
+create_gains_curve <- function(
+  probs,
+  reals,
+  by = 0.01,
+  stratified_by = "probability_threshold",
+  chosen_threshold = NA,
+  interactive = TRUE,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  ),
+  size = NULL
+) {
   if (!is.na(chosen_threshold)) {
     check_chosen_threshold_input(chosen_threshold)
   }
@@ -139,24 +153,40 @@ create_gains_curve <- function(probs, reals, by = 0.01,
 #'
 #' @export
 
-plot_gains_curve <- function(performance_data,
-                             chosen_threshold = NA,
-                             interactive = TRUE,
-                             color_values = c(
-                               "#1b9e77", "#d95f02",
-                               "#7570b3", "#e7298a",
-                               "#07004D", "#E6AB02",
-                               "#FE5F55", "#54494B",
-                               "#006E90", "#BC96E6",
-                               "#52050A", "#1F271B",
-                               "#BE7C4D", "#63768D",
-                               "#08A045", "#320A28",
-                               "#82FF9E", "#2176FF",
-                               "#D1603D", "#585123"
-                             ),
-                             size = NULL) {
+plot_gains_curve <- function(
+  performance_data,
+  chosen_threshold = NA,
+  interactive = TRUE,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  ),
+  size = NULL
+) {
   rtichoke_curve_list <- performance_data |>
-    create_rtichoke_curve_list("gains", size = size, color_values = color_values)
+    create_rtichoke_curve_list(
+      "gains",
+      size = size,
+      color_values = color_values
+    )
 
   if (!is.na(chosen_threshold)) {
     check_chosen_threshold_input(chosen_threshold)
@@ -179,7 +209,8 @@ plot_gains_curve <- function(performance_data,
 
     gains_curve <- performance_data |>
       create_ggplot_for_performance_metrics(
-        "ppcr", "sensitivity",
+        "ppcr",
+        "sensitivity",
         color_values
       ) |>
       add_reference_lines_to_ggplot(reference_lines) |>
@@ -205,7 +236,8 @@ add_gains_curve_reference_lines <- function(gains_curve, prevalence) {
   gains_curve$layers <- c(
     ggplot2::geom_segment(x = 0, y = 0, xend = 1, yend = 1, color = "grey"),
     purrr::map2(
-      prevalence, c(
+      prevalence,
+      c(
         "#5BC0BE",
         "#FC8D62",
         "#8DA0CB",
@@ -213,7 +245,8 @@ add_gains_curve_reference_lines <- function(gains_curve, prevalence) {
         "#A4243B"
       )[seq_len(length(prevalence))],
       add_prevalence_layers_to_gains_curve
-    ) |> unlist(),
+    ) |>
+      unlist(),
     gains_curve$layers
   )
   gains_curve

--- a/R/gains.R
+++ b/R/gains.R
@@ -43,32 +43,32 @@
 #'
 #' create_gains_curve(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   )
 #' )
 #'
 #' create_gains_curve(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   ),
 #'   stratified_by = "ppcr"
@@ -100,7 +100,7 @@ create_gains_curve <- function(probs, reals, by = 0.01,
     reals = reals,
     by = by,
     stratified_by = stratified_by
-  ) %>%
+  ) |>
     plot_gains_curve(
       chosen_threshold = chosen_threshold,
       interactive = interactive,
@@ -118,22 +118,22 @@ create_gains_curve <- function(probs, reals, by = 0.01,
 #' @examples
 #' \dontrun{
 #'
-#' one_pop_one_model %>%
+#' one_pop_one_model |>
 #'   plot_gains_curve()
 #'
-#' one_pop_one_model_by_ppcr %>%
+#' one_pop_one_model_by_ppcr |>
 #'   plot_gains_curve()
 #'
-#' multiple_models %>%
+#' multiple_models |>
 #'   plot_gains_curve()
 #'
-#' multiple_models_by_ppcr %>%
+#' multiple_models_by_ppcr |>
 #'   plot_gains_curve()
 #'
-#' multiple_populations %>%
+#' multiple_populations |>
 #'   plot_gains_curve()
 #'
-#' multiple_populations_by_ppcr %>%
+#' multiple_populations_by_ppcr |>
 #'   plot_gains_curve()
 #' }
 #'
@@ -177,12 +177,12 @@ plot_gains_curve <- function(performance_data,
   if (interactive == FALSE) {
     reference_lines <- create_reference_lines_data_frame("gains", prevalence)
 
-    gains_curve <- performance_data %>%
+    gains_curve <- performance_data |>
       create_ggplot_for_performance_metrics(
         "ppcr", "sensitivity",
         color_values
-      ) %>%
-      add_reference_lines_to_ggplot(reference_lines) %>%
+      ) |>
+      add_reference_lines_to_ggplot(reference_lines) |>
       set_gains_curve_limits() +
       ggplot2::xlab("Predicted Positives (Rate)") +
       ggplot2::ylab("Sensitivity")
@@ -213,7 +213,7 @@ add_gains_curve_reference_lines <- function(gains_curve, prevalence) {
         "#A4243B"
       )[seq_len(length(prevalence))],
       add_prevalence_layers_to_gains_curve
-    ) %>% unlist(),
+    ) |> unlist(),
     gains_curve$layers
   )
   gains_curve

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -6,9 +6,10 @@
 #' @param performance_data_type the type of the Performance Data
 #'
 #' @keywords internal
-get_real_positives_from_performance_data <- function(performance_data,
-                                                     performance_data_type =
-                                                       "not important") {
+get_real_positives_from_performance_data <- function(
+  performance_data,
+  performance_data_type = "not important"
+) {
   real_positives <- real_positives <- NULL
 
   real_positives <- performance_data |>
@@ -29,9 +30,10 @@ get_real_positives_from_performance_data <- function(performance_data,
 #' @param performance_data_type the type of the Performance Data
 #'
 #' @keywords internal
-get_prevalence_from_performance_data <- function(performance_data,
-                                                 performance_data_type =
-                                                   "not important") {
+get_prevalence_from_performance_data <- function(
+  performance_data,
+  performance_data_type = "not important"
+) {
   PPV <- ppcr <- NULL
 
   prevalence <- performance_data |>
@@ -51,9 +53,10 @@ get_prevalence_from_performance_data <- function(performance_data,
 #' @param performance_data_type the type of the Performance Data
 #'
 #' @keywords internal
-get_n_from_performance_data <- function(performance_data,
-                                        performance_data_type =
-                                          "not important") {
+get_n_from_performance_data <- function(
+  performance_data,
+  performance_data_type = "not important"
+) {
   predicted_positives <- ppcr <- NULL
 
   # print(performance_data)
@@ -83,17 +86,22 @@ get_n_from_performance_data <- function(performance_data,
 #' @param color the required color
 #' @keywords internal
 
-create_reference_lines_data_frame <- function(curve,
-                                              prevalence = NA,
-                                              color = NA,
-                                              plotly = FALSE,
-                                              multiple_pop = FALSE,
-                                              performance_data = NULL) {
+create_reference_lines_data_frame <- function(
+  curve,
+  prevalence = NA,
+  color = NA,
+  plotly = FALSE,
+  multiple_pop = FALSE,
+  performance_data = NULL
+) {
   if (curve == "roc") {
     if (plotly == FALSE) {
       reference_lines_data_frame <- data.frame(
-        x = 0, xend = 1, y = 0,
-        yend = 1, col = "grey",
+        x = 0,
+        xend = 1,
+        y = 0,
+        yend = 1,
+        col = "grey",
         linetype = "solid"
       )
     } else {
@@ -108,8 +116,10 @@ create_reference_lines_data_frame <- function(curve,
   if (curve == "lift") {
     if (plotly == FALSE) {
       reference_lines_data_frame <- data.frame(
-        x = 0, xend = 1,
-        y = 1, yend = 1,
+        x = 0,
+        xend = 1,
+        y = 1,
+        yend = 1,
         col = "grey",
         linetype = "solid"
       )
@@ -133,7 +143,11 @@ create_reference_lines_data_frame <- function(curve,
     }
     if (plotly == FALSE) {
       reference_lines_data_frame <- data.frame(
-        x = 0, xend = 1, y = prevalence, yend = prevalence, col = color_values,
+        x = 0,
+        xend = 1,
+        y = prevalence,
+        yend = prevalence,
+        col = color_values,
         linetype = "dotted"
       )
     } else {
@@ -176,7 +190,11 @@ create_reference_lines_data_frame <- function(curve,
       ) |>
         bind_rows(
           data.frame(
-            x = 0, xend = 1, y = 0, yend = 1, col = "grey",
+            x = 0,
+            xend = 1,
+            y = 0,
+            yend = 1,
+            col = "grey",
             linetype = "dotted"
           )
         )
@@ -223,8 +241,9 @@ create_reference_lines_data_frame <- function(curve,
           dplyr::mutate(
             population = "treat_all",
             x = probability_threshold,
-            y = prevalence - (1 - prevalence) *
-              (probability_threshold / (1 - probability_threshold))
+            y = prevalence -
+              (1 - prevalence) *
+                (probability_threshold / (1 - probability_threshold))
           ) |>
           dplyr::select(population, x, y) |>
           dplyr::bind_rows(
@@ -232,10 +251,12 @@ create_reference_lines_data_frame <- function(curve,
           ) |>
           dplyr::mutate(
             text = dplyr::case_when(
-              population != "treat_none" ~ glue::glue("<b>NB Treat All:</b> \\
+              population != "treat_none" ~ glue::glue(
+                "<b>NB Treat All:</b> \\
                               {round(y, digits = 3)} <br>\\
                               <b>Prob. Threshold:</b> \\
-                              {round(x, digits = 3)} "),
+                              {round(x, digits = 3)} "
+              ),
               TRUE ~ "<b>NB Treat None:</b> 0"
             )
           )
@@ -247,14 +268,17 @@ create_reference_lines_data_frame <- function(curve,
           ) |>
           dplyr::mutate(
             x = probability_threshold,
-            y = prevalence - (1 - prevalence) *
-              (probability_threshold / (1 - probability_threshold)),
+            y = prevalence -
+              (1 - prevalence) *
+                (probability_threshold / (1 - probability_threshold)),
             linetype = "solid"
           ) |>
           dplyr::select(population, x, y, linetype) |>
           dplyr::bind_rows(
             data.frame(
-              population = "treat_none", x = c(0, 1), y = c(0, 0),
+              population = "treat_none",
+              x = c(0, 1),
+              y = c(0, 0),
               linetype = "dotted"
             )
           ) |>
@@ -287,25 +311,31 @@ create_reference_lines_data_frame <- function(curve,
       )[seq_len(length(prevalence))]
     }
 
-
-
-
     reference_lines_data_frame <- data.frame(
-      x = 0, xend = prevalence, y = prevalence, yend = 0, col = color_values,
+      x = 0,
+      xend = prevalence,
+      y = prevalence,
+      yend = 0,
+      col = color_values,
       linetype = "dotted"
     )
   }
 
   if (curve == "decision treat none") {
     reference_lines_data_frame <- data.frame(
-      x = 0, xend = 1, y = 0, yend = 0, col = "grey",
+      x = 0,
+      xend = 1,
+      y = 0,
+      yend = 0,
+      col = "grey",
       linetype = "solid"
     )
   }
 
   if (curve == "interventions avoided") {
     reference_lines_data_frame <- data.frame(
-      x = numeric(), y = numeric()
+      x = numeric(),
+      y = numeric()
     )
   }
 
@@ -345,7 +375,6 @@ add_reference_lines_to_ggplot <- function(ggplot_curve, reference_lines) {
 }
 
 
-
 #' Creating subtitle for ggplot2
 #'
 #' @inheritParams create_roc_curve
@@ -359,20 +388,22 @@ add_reference_lines_to_ggplot <- function(ggplot_curve, reference_lines) {
 #'   )
 #' )
 #' }
-create_subtitle_for_ggplot <- function(probs_names, color_values = c(
-                                         "#5BC0BE",
-                                         "#FC8D62",
-                                         "#8DA0CB",
-                                         "#E78AC3",
-                                         "#A4243B"
-                                       )) {
-  subtitle <- glue::glue("{probs_names},
-                         {color_values[1:length(probs_names)]}")
+create_subtitle_for_ggplot <- function(
+  probs_names,
+  color_values = c(
+    "#5BC0BE",
+    "#FC8D62",
+    "#8DA0CB",
+    "#E78AC3",
+    "#A4243B"
+  )
+) {
+  subtitle <- glue::glue(
+    "{probs_names},
+                         {color_values[1:length(probs_names)]}"
+  )
   subtitle
 }
-
-
-
 
 
 #' Creating rtichoke curve list
@@ -402,22 +433,35 @@ create_subtitle_for_ggplot <- function(probs_names, color_values = c(
 #' multiple_populations_by_ppcr |>
 #'   create_rtichoke_curve_list("roc")
 #' }
-create_rtichoke_curve_list <- function(performance_data,
-                                       curve,
-                                       min_p_threshold = 0,
-                                       max_p_threshold = 1,
-                                       size = NULL, color_values = c(
-                                         "#1b9e77", "#d95f02",
-                                         "#7570b3", "#e7298a",
-                                         "#07004D", "#E6AB02",
-                                         "#FE5F55", "#54494B",
-                                         "#006E90", "#BC96E6",
-                                         "#52050A", "#1F271B",
-                                         "#BE7C4D", "#63768D",
-                                         "#08A045", "#320A28",
-                                         "#82FF9E", "#2176FF",
-                                         "#D1603D", "#585123"
-                                       )) {
+create_rtichoke_curve_list <- function(
+  performance_data,
+  curve,
+  min_p_threshold = 0,
+  max_p_threshold = 1,
+  size = NULL,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  )
+) {
   rtichoke_curve_list <- list()
 
   rtichoke_curve_list$size <- list(size)
@@ -425,8 +469,9 @@ create_rtichoke_curve_list <- function(performance_data,
   stratified_by <- check_performance_data_stratification(
     performance_data
   )
-  
-  rtichoke_curve_list$animation_slider_prefix <- ifelse(stratified_by == "probability_threshold",
+
+  rtichoke_curve_list$animation_slider_prefix <- ifelse(
+    stratified_by == "probability_threshold",
     "Prob. Threshold: ",
     "Predicted Positives (Rate):"
   )
@@ -435,13 +480,19 @@ create_rtichoke_curve_list <- function(performance_data,
     performance_data = performance_data
   )
 
-
   rtichoke_curve_list$group_colors_vec <- performance_data |>
-    extract_reference_groups_from_performance_data(rtichoke_curve_list$perf_dat_type) |>
-    create_reference_group_color_vector(rtichoke_curve_list$perf_dat_type, color_values = color_values) |>
+    extract_reference_groups_from_performance_data(
+      rtichoke_curve_list$perf_dat_type
+    ) |>
+    create_reference_group_color_vector(
+      rtichoke_curve_list$perf_dat_type,
+      color_values = color_values
+    ) |>
     as.list()
 
-  prevalence_from_performance_data <- get_prevalence_from_performance_data(performance_data) |>
+  prevalence_from_performance_data <- get_prevalence_from_performance_data(
+    performance_data
+  ) |>
     as.list()
 
   rtichoke_curve_list$reference_data <- create_reference_lines_data(
@@ -499,14 +550,14 @@ create_rtichoke_curve_list <- function(performance_data,
       min_p_threshold = min_p_threshold,
       max_p_threshold = max_p_threshold
     )
-  
-  
+
   rtichoke_curve_list$performance_data_for_interactive_marker <- prepare_performance_data_for_interactive_marker(
     rtichoke_curve_list$performance_data_ready_for_curve,
-    rtichoke_curve_list$perf_dat_type)
+    rtichoke_curve_list$perf_dat_type
+  )
 
-
-  rtichoke_curve_list$axes_ranges <- extract_axes_ranges(rtichoke_curve_list$performance_data_ready_for_curve,
+  rtichoke_curve_list$axes_ranges <- extract_axes_ranges(
+    rtichoke_curve_list$performance_data_ready_for_curve,
     curve,
     min_p_threshold = min_p_threshold,
     max_p_threshold = max_p_threshold
@@ -549,7 +600,8 @@ create_rtichoke_curve_list <- function(performance_data,
 #'   create_plotly_curve()
 #' }
 create_plotly_curve <- function(rtichoke_curve_list) {
-  size_height <- switch(is.null(rtichoke_curve_list$size[[1]]) + 1,
+  size_height <- switch(
+    is.null(rtichoke_curve_list$size[[1]]) + 1,
     rtichoke_curve_list$size[[1]] + 50,
     NULL
   )
@@ -562,10 +614,13 @@ create_plotly_curve <- function(rtichoke_curve_list) {
     )
   )
 
-  if (!(rtichoke_curve_list$perf_dat_type %in% c("several models", "several populations"))) {
+  if (
+    !(rtichoke_curve_list$perf_dat_type %in%
+      c("several models", "several populations"))
+  ) {
     interactive_marker$color <- "#f6e3be"
   }
-  
+
   plotly::plot_ly(
     x = ~x,
     y = ~y,
@@ -595,12 +650,14 @@ create_plotly_curve <- function(rtichoke_curve_list) {
     ) |>
     plotly::layout(
       xaxis = list(
-        showgrid = FALSE, fixedrange = TRUE,
+        showgrid = FALSE,
+        fixedrange = TRUE,
         range = rtichoke_curve_list$axes_ranges$xaxis,
         title = rtichoke_curve_list$axes_labels$xaxis
       ),
       yaxis = list(
-        showgrid = FALSE, fixedrange = TRUE,
+        showgrid = FALSE,
+        fixedrange = TRUE,
         range = rtichoke_curve_list$axes_ranges$yaxis,
         title = rtichoke_curve_list$axes_labels$yaxis
       ),
@@ -648,30 +705,54 @@ create_plotly_curve <- function(rtichoke_curve_list) {
 #' multiple_populations_by_ppcr |>
 #'   plot_rtichoke_curve("roc")
 #' }
-plot_rtichoke_curve <- function(performance_data, curve, color_values = c(
-                                  "#1b9e77", "#d95f02",
-                                  "#7570b3", "#e7298a",
-                                  "#07004D", "#E6AB02",
-                                  "#FE5F55", "#54494B",
-                                  "#006E90", "#BC96E6",
-                                  "#52050A", "#1F271B",
-                                  "#BE7C4D", "#63768D",
-                                  "#08A045", "#320A28",
-                                  "#82FF9E", "#2176FF",
-                                  "#D1603D", "#585123"
-                                ), min_p_threshold = 0, max_p_threshold = 1, size = NULL) {
+plot_rtichoke_curve <- function(
+  performance_data,
+  curve,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  ),
+  min_p_threshold = 0,
+  max_p_threshold = 1,
+  size = NULL
+) {
   check_curve_input(curve)
 
   stratified_by <- check_performance_data_stratification(
     performance_data
   )
 
-  prevalence_from_performance_data <- get_prevalence_from_performance_data(performance_data)
-  perf_dat_type <- check_performance_data_type_for_plotly(performance_data = performance_data)
+  prevalence_from_performance_data <- get_prevalence_from_performance_data(
+    performance_data
+  )
+  perf_dat_type <- check_performance_data_type_for_plotly(
+    performance_data = performance_data
+  )
 
   reference_group_colors_vec <- performance_data |>
     extract_reference_groups_from_performance_data(perf_dat_type) |>
-    create_reference_group_color_vector(perf_dat_type, color_values = color_values)
+    create_reference_group_color_vector(
+      perf_dat_type,
+      color_values = color_values
+    )
 
   if (curve == "roc") {
     x_performance_metric <- "FPR"
@@ -692,7 +773,6 @@ plot_rtichoke_curve <- function(performance_data, curve, color_values = c(
     x_performance_metric <- "probability_threshold"
     y_performance_metric <- "NB_interventions_avoided"
   }
-
 
   performance_data_ready_for_curve <- performance_data |>
     prepare_performance_data_for_curve(
@@ -721,9 +801,11 @@ plot_rtichoke_curve <- function(performance_data, curve, color_values = c(
     max_p_threshold
   ) |>
     add_markers_and_lines_for_plotly_reference_object(
-      performance_data_ready_for_curve, perf_dat_type
+      performance_data_ready_for_curve,
+      perf_dat_type
     ) |>
-    set_styling_for_rtichoke(curve,
+    set_styling_for_rtichoke(
+      curve,
       min_x_range = axis_ranges$xaxis[1],
       max_x_range = axis_ranges$xaxis[2],
       min_y_range = axis_ranges$yaxis[1],
@@ -731,7 +813,8 @@ plot_rtichoke_curve <- function(performance_data, curve, color_values = c(
     ) |>
     plotly::animation_slider(
       currentvalue = list(
-        prefix = ifelse(stratified_by == "probability_threshold",
+        prefix = ifelse(
+          stratified_by == "probability_threshold",
           "Prob. Threshold: ",
           "Predicted Positives (Rate):"
         ),
@@ -741,7 +824,6 @@ plot_rtichoke_curve <- function(performance_data, curve, color_values = c(
       pad = list(t = 50)
     )
 }
-
 
 
 check_performance_type_by_probs_and_reals <- function(probs, reals) {
@@ -757,7 +839,10 @@ check_performance_type_by_probs_and_reals <- function(probs, reals) {
 }
 
 
-extract_reference_groups_from_performance_data <- function(performance_data, perf_data_type) {
+extract_reference_groups_from_performance_data <- function(
+  performance_data,
+  perf_data_type
+) {
   if (perf_data_type == "several models") {
     reference_groups <- unique(performance_data$model)
   } else if (perf_data_type == "several populations") {
@@ -770,20 +855,24 @@ extract_reference_groups_from_performance_data <- function(performance_data, per
 }
 
 
-
-
-
 make_deciles_dat_new <- function(probs, reals) {
   data.frame(probs, reals) |>
     dplyr::mutate(quintile = dplyr::ntile(probs, 10)) |>
     dplyr::group_by(quintile) |>
-    dplyr::summarise(y = sum(reals) / n(), x = mean(probs), sum_reals = sum(reals), total_obs = n()) |>
+    dplyr::summarise(
+      y = sum(reals) / n(),
+      x = mean(probs),
+      sum_reals = sum(reals),
+      total_obs = n()
+    ) |>
     dplyr::ungroup()
 }
 
-create_reference_group_color_vector <- function(reference_groups,
-                                                perf_dat_type,
-                                                color_values) {
+create_reference_group_color_vector <- function(
+  reference_groups,
+  perf_dat_type,
+  color_values
+) {
   if (!(perf_dat_type %in% c("several populations", "several models"))) {
     color_values <- "black"
   }
@@ -813,22 +902,28 @@ create_reference_group_color_vector <- function(reference_groups,
   reference_group_color_vector
 }
 
-prepare_performance_data_for_curve <- function(performance_data,
-                                               x_performance_metric,
-                                               y_performance_metric,
-                                               stratified_by,
-                                               perf_dat_type,
-                                               min_p_threshold = 0,
-                                               max_p_threshold = 1) {
+prepare_performance_data_for_curve <- function(
+  performance_data,
+  x_performance_metric,
+  y_performance_metric,
+  stratified_by,
+  perf_dat_type,
+  min_p_threshold = 0,
+  max_p_threshold = 1
+) {
   performance_data |>
     (\(data) {
       if (y_performance_metric == "NB_interventions_avoided") {
-        dplyr::mutate(data,
+        dplyr::mutate(
+          data,
           N = TP + TN + FP + FN,
           prevalence = (TP + FN) / N,
-          NB_intervention_all = prevalence - (1 - prevalence) *
-            (probability_threshold) / (1 - probability_threshold),
-          NB_interventions_avoided = 100 * (NB - NB_intervention_all) *
+          NB_intervention_all = prevalence -
+            (1 - prevalence) *
+              (probability_threshold) /
+              (1 - probability_threshold),
+          NB_interventions_avoided = 100 *
+            (NB - NB_intervention_all) *
             ((1 - probability_threshold) / probability_threshold)
         )
       } else {
@@ -845,7 +940,10 @@ prepare_performance_data_for_curve <- function(performance_data,
       }
     })() |>
     add_hover_text_to_performance_data_new(
-      x_performance_metric, y_performance_metric, stratified_by, perf_dat_type
+      x_performance_metric,
+      y_performance_metric,
+      stratified_by,
+      perf_dat_type
     ) |>
     select_and_rename_necessary_variables(
       x_performance_metric,
@@ -863,11 +961,13 @@ prepare_performance_data_for_curve <- function(performance_data,
 }
 
 
-add_hover_text_to_performance_data_new <- function(performance_data,
-                                                   performance_metric_x,
-                                                   performance_metric_y,
-                                                   stratified_by,
-                                                   perf_dat_type) {
+add_hover_text_to_performance_data_new <- function(
+  performance_data,
+  performance_metric_x,
+  performance_metric_y,
+  stratified_by,
+  perf_dat_type
+) {
   hover_text <- create_hover_text(
     stratified_by = stratified_by,
     interventions_avoided = (performance_metric_y == "NB_interventions_avoided")
@@ -894,17 +994,11 @@ add_hover_text_to_performance_data_new <- function(performance_data,
 }
 
 add_models_for_text_for_hover_new <- function(text_for_hover) {
-  paste("<b>Model: {model}</b>",
-    text_for_hover,
-    sep = "<br>"
-  )
+  paste("<b>Model: {model}</b>", text_for_hover, sep = "<br>")
 }
 
 add_population_for_text_for_hover_new <- function(text_for_hover) {
-  paste("<b>Population: {population}</b>",
-    text_for_hover,
-    sep = "<br>"
-  )
+  paste("<b>Population: {population}</b>", text_for_hover, sep = "<br>")
 }
 
 
@@ -918,7 +1012,8 @@ Specificity: {specificity}<br>\\
 Lift: {lift}<br>\\
 PPV: {PPV}<br>\\
 NPV: {NPV}<br>",
-      ifelse(stratified_by == "probability_threshold",
+      ifelse(
+        stratified_by == "probability_threshold",
         "NB: {NB}<br>\\
 Odds of Prob. Threshold: 1:{round((1 - probability_threshold) / probability_threshold, digits = 2)}<br>",
         ""
@@ -943,15 +1038,16 @@ FN: {FN}"
 }
 
 
-select_and_rename_necessary_variables <- function(performance_data,
-                                                  x_perf_metric,
-                                                  y_perf_metric,
-                                                  stratified_by,
-                                                  perf_dat_type) {
+select_and_rename_necessary_variables <- function(
+  performance_data,
+  x_perf_metric,
+  y_perf_metric,
+  stratified_by,
+  perf_dat_type
+) {
   x_perf_metric <- sym(x_perf_metric)
   y_perf_metric <- sym(y_perf_metric)
   stratified_by <- sym(stratified_by)
-
 
   if (!(perf_dat_type %in% c("several populations", "several models"))) {
     performance_data <- performance_data |>
@@ -964,7 +1060,6 @@ select_and_rename_necessary_variables <- function(performance_data,
     reference_group <- sym("model")
   }
 
-
   performance_data |>
     dplyr::select(
       reference_group = {{ reference_group }},
@@ -975,9 +1070,11 @@ select_and_rename_necessary_variables <- function(performance_data,
     )
 }
 
-add_markers_and_lines_for_plotly_reference_object <- function(plotly_object,
-                                                              performance_data_ready,
-                                                              perf_dat_type) {
+add_markers_and_lines_for_plotly_reference_object <- function(
+  plotly_object,
+  performance_data_ready,
+  perf_dat_type
+) {
   interactive_marker <- list(
     size = 12,
     line = list(
@@ -1004,17 +1101,16 @@ add_markers_and_lines_for_plotly_reference_object <- function(plotly_object,
     )
 }
 
-create_reference_lines_for_plotly_new <- function(curve,
-                                                  prevalence,
-                                                  reference_group_colors,
-                                                  perf_dat_type,
-                                                  size,
-                                                  min_p_threshold,
-                                                  max_p_threshold) {
-  size_height <- switch(is.null(size) + 1,
-    size + 50,
-    NULL
-  )
+create_reference_lines_for_plotly_new <- function(
+  curve,
+  prevalence,
+  reference_group_colors,
+  perf_dat_type,
+  size,
+  min_p_threshold,
+  max_p_threshold
+) {
+  size_height <- switch(is.null(size) + 1, size + 50, NULL)
 
   plot_ly(
     x = ~x,
@@ -1028,7 +1124,8 @@ create_reference_lines_for_plotly_new <- function(curve,
   ) |>
     plotly::add_lines(
       data = create_reference_lines_data(
-        curve, prevalence,
+        curve,
+        prevalence,
         perf_dat_type,
         min_p_threshold,
         max_p_threshold
@@ -1039,10 +1136,13 @@ create_reference_lines_for_plotly_new <- function(curve,
     )
 }
 
-create_reference_lines_data <- function(curve, prevalence,
-                                        perf_dat_type,
-                                        min_p_threshold,
-                                        max_p_threshold) {
+create_reference_lines_data <- function(
+  curve,
+  prevalence,
+  perf_dat_type,
+  min_p_threshold,
+  max_p_threshold
+) {
   check_curve_input(curve)
 
   if (curve == "roc") {
@@ -1052,20 +1152,27 @@ create_reference_lines_data <- function(curve, prevalence,
       y = seq(0, 1, by = 0.01)
     ) |>
       dplyr::mutate(
-        text =
-          glue::glue(
-            "<b>Random Guess</b><br>Sensitivity: {y}<br>1 - Specificity: {x}"
-          )
+        text = glue::glue(
+          "<b>Random Guess</b><br>Sensitivity: {y}<br>1 - Specificity: {x}"
+        )
       )
   }
 
   if (curve == "lift") {
-    
     hover_text_random <- "<b>Random Guess</b><br>Lift: {y}<br>Predicted Positives: {100*x}%"
-    
+
     if (perf_dat_type == "several populations") {
-      reference_group <- rep(c("reference_line", paste0("reference_line_perfect_model_", names(prevalence))), each = 100)
-      reference_line_x_values <- rep(seq(0.01, 1, by = 0.01), times = (length(prevalence) + 1))
+      reference_group <- rep(
+        c(
+          "reference_line",
+          paste0("reference_line_perfect_model_", names(prevalence))
+        ),
+        each = 100
+      )
+      reference_line_x_values <- rep(
+        seq(0.01, 1, by = 0.01),
+        times = (length(prevalence) + 1)
+      )
 
       reference_line_y_values <- c(
         rep(1, 100),
@@ -1075,28 +1182,26 @@ create_reference_lines_data <- function(curve, prevalence,
       )
       hover_text_perfect <- "<b>Perfect Prediction ({reference_group})</b><br>Lift: {round(y, digits = 3)}<br>Predicted Positives: {100*x}%"
     } else {
-      
-      if((unique(unlist(prevalence))) == 0) {
-        
+      if ((unique(unlist(prevalence))) == 0) {
         random_guess <- rep(NaN, 100)
-        
       } else {
-        
         random_guess <- rep(1, 100)
-        
       }
-      
-      reference_group <- rep(c("reference_line", "reference_line_perfect_model"), each = 100)
+
+      reference_group <- rep(
+        c("reference_line", "reference_line_perfect_model"),
+        each = 100
+      )
       reference_line_x_values <- rep(seq(0.01, 1, by = 0.01), times = 2)
 
       reference_line_y_values <- c(
         random_guess,
         return_perfect_prediction_lift_y_values(unique(unlist(prevalence)))
       )
-      
+
       hover_text_perfect <- "<b>Perfect Prediction</b><br>Lift: {round(y, digits = 3)}<br>Predicted Positives: {100*x}%"
     }
-    
+
     reference_lines_data <- data.frame(
       reference_group = reference_group,
       x = reference_line_x_values,
@@ -1107,11 +1212,15 @@ create_reference_lines_data <- function(curve, prevalence,
           reference_group == "reference_line" ~ glue::glue(hover_text_random),
           TRUE ~ glue::glue(hover_text_perfect)
         ),
-        text = stringr::str_replace(.data$text, "reference_line_perfect_model_", "")
+        text = stringr::str_replace(
+          .data$text,
+          "reference_line_perfect_model_",
+          ""
+        )
       )
-    
+
     # TODO: remove the code below ->
-    
+
     # reference_lines_data <- data.frame(
     #   reference_group = "reference_line",
     #   x = seq(0.01, 1, by = 0.01),
@@ -1128,7 +1237,10 @@ create_reference_lines_data <- function(curve, prevalence,
   if (curve == "precision recall") {
     if (perf_dat_type == "several populations") {
       reference_group <- rep(names(prevalence), each = 100)
-      reference_line_x_values <- rep(seq(0.01, 1, by = 0.01), times = length(prevalence))
+      reference_line_x_values <- rep(
+        seq(0.01, 1, by = 0.01),
+        times = length(prevalence)
+      )
       reference_line_y_values <- rep(unlist(prevalence), each = 100)
       hover_text <- "<b>Random Guess ({reference_group})</b><br>PPV: {round(y, digits = 3)}<br>Sensitivity: {x}"
     } else {
@@ -1137,7 +1249,6 @@ create_reference_lines_data <- function(curve, prevalence,
       reference_line_y_values <- rep(unique(unlist(prevalence)), 100)
       hover_text <- "<b>Random Guess</b><br>PPV: {round(y, digits = 3)}<br>Sensitivity: {x}"
     }
-
 
     reference_lines_data <- data.frame(
       reference_group = reference_group,
@@ -1151,8 +1262,17 @@ create_reference_lines_data <- function(curve, prevalence,
     hover_text_random <- "<b>Random Guess</b><br>Sensitivity: {round(y, digits = 3)}<br>Predicted Positives: {100*x}%"
 
     if (perf_dat_type == "several populations") {
-      reference_group <- rep(c("reference_line", paste0("reference_line_perfect_model_", names(prevalence))), each = 101)
-      reference_line_x_values <- rep(seq(0, 1, by = 0.01), times = (length(prevalence) + 1))
+      reference_group <- rep(
+        c(
+          "reference_line",
+          paste0("reference_line_perfect_model_", names(prevalence))
+        ),
+        each = 101
+      )
+      reference_line_x_values <- rep(
+        seq(0, 1, by = 0.01),
+        times = (length(prevalence) + 1)
+      )
       reference_line_y_values <- c(
         seq(0, 1, by = 0.01),
         prevalence |>
@@ -1161,7 +1281,10 @@ create_reference_lines_data <- function(curve, prevalence,
       )
       hover_text_perfect <- "<b>Perfect Prediction ({reference_group})</b><br>Sensitivity: {round(y, digits = 3)}<br>Predicted Positives: {100*x}%"
     } else {
-      reference_group <- rep(c("reference_line", "reference_line_perfect_model"), each = 101)
+      reference_group <- rep(
+        c("reference_line", "reference_line_perfect_model"),
+        each = 101
+      )
       reference_line_x_values <- rep(seq(0, 1, by = 0.01), times = 2)
       reference_line_y_values <- c(
         seq(0, 1, by = 0.01),
@@ -1181,7 +1304,11 @@ create_reference_lines_data <- function(curve, prevalence,
           reference_group == "reference_line" ~ glue::glue(hover_text_random),
           TRUE ~ glue::glue(hover_text_perfect)
         ),
-        text = stringr::str_replace(.data$text, "reference_line_perfect_model_", "")
+        text = stringr::str_replace(
+          .data$text,
+          "reference_line_perfect_model_",
+          ""
+        )
       )
   }
 
@@ -1194,7 +1321,10 @@ create_reference_lines_data <- function(curve, prevalence,
         ),
         each = 100
       )
-      reference_line_x_values <- rep(seq(0, 0.99, by = 0.01), times = (length(prevalence) + 1))
+      reference_line_x_values <- rep(
+        seq(0, 0.99, by = 0.01),
+        times = (length(prevalence) + 1)
+      )
       reference_line_y_values <- c(
         rep(0, 100),
         prevalence |>
@@ -1204,15 +1334,24 @@ create_reference_lines_data <- function(curve, prevalence,
 
       hover_text_treat_all <- "<b>Treat All ({reference_group})</b><br>NB: {round(y, digits = 3)}<br>Probability Threshold: {x}<br>Odds of Prob. Threshold: 1:{round((1 - x) / x, digits = 2)}"
     } else {
-      reference_group <- rep(c("reference_line", "reference_line_treat_all"), each = 100)
+      reference_group <- rep(
+        c("reference_line", "reference_line_treat_all"),
+        each = 100
+      )
       reference_line_x_values <- rep(seq(0, 0.99, by = 0.01), times = 2)
-      reference_line_y_values <- c(rep(0, 100), c(unique(unlist(prevalence)) - (1 - unique(unlist(prevalence))) *
-        (seq(0, 0.99, by = 0.01)) / (1 - seq(0, 0.99, by = 0.01))))
+      reference_line_y_values <- c(
+        rep(0, 100),
+        c(
+          unique(unlist(prevalence)) -
+            (1 - unique(unlist(prevalence))) *
+              (seq(0, 0.99, by = 0.01)) /
+              (1 - seq(0, 0.99, by = 0.01))
+        )
+      )
       hover_text_treat_all <- "<b>Treat All</b><br>NB: {round(y, digits = 3)}<br>Probability Threshold: {x}<br>Odds of Prob. Threshold: 1:{round((1 - x) / x, digits = 2)}"
     }
 
     hover_text_treat_none <- "<b>Treat None</b><br>NB: 0<br>Probability Threshold: {x}<br>Odds of Prob. Threshold: 1:{round((1 - x) / x, digits = 2)}"
-
 
     reference_lines_data <- data.frame(
       reference_group = reference_group,
@@ -1221,7 +1360,9 @@ create_reference_lines_data <- function(curve, prevalence,
     ) |>
       dplyr::mutate(
         text = dplyr::case_when(
-          reference_group == "reference_line" ~ glue::glue(hover_text_treat_none),
+          reference_group == "reference_line" ~ glue::glue(
+            hover_text_treat_none
+          ),
           TRUE ~ glue::glue(hover_text_treat_all)
         ),
         text = stringr::str_replace(.data$text, "reference_line_treat_all_", "")
@@ -1238,20 +1379,36 @@ create_reference_lines_data <- function(curve, prevalence,
         ),
         each = 99
       )
-      reference_line_x_values <- rep(seq(0.01, 0.99, by = 0.01), times = (length(prevalence) + 1))
-      reference_line_y_values <- 100 * c(
-        rep(0, 99),
-        prevalence |>
-          purrr::map(~ return_treat_none_y_values(.x)) |>
-          unlist()
+      reference_line_x_values <- rep(
+        seq(0.01, 0.99, by = 0.01),
+        times = (length(prevalence) + 1)
       )
+      reference_line_y_values <- 100 *
+        c(
+          rep(0, 99),
+          prevalence |>
+            purrr::map(~ return_treat_none_y_values(.x)) |>
+            unlist()
+        )
 
       hover_text_treat_none <- "<b>Treat None ({reference_group})</b><br>Interventions Avoided (per 100): {round(y, digits = 3)}<br>Probability Threshold: {x}<br>Odds of Prob. Threshold: 1:{round((1 - x) / x, digits = 2)}"
     } else {
-      reference_group <- rep(c("reference_line", "reference_line_treat_none"), each = 99)
+      reference_group <- rep(
+        c("reference_line", "reference_line_treat_none"),
+        each = 99
+      )
       reference_line_x_values <- rep(seq(0.01, 0.99, by = 0.01), times = 2)
-      reference_line_y_values <- 100 * c(rep(0, 99), c(1 - unique(unlist(prevalence)) - unique(unlist(prevalence)) *
-        (1 - seq(0.01, 0.99, by = 0.01)) / (seq(0.01, 0.99, by = 0.01))))
+      reference_line_y_values <- 100 *
+        c(
+          rep(0, 99),
+          c(
+            1 -
+              unique(unlist(prevalence)) -
+              unique(unlist(prevalence)) *
+                (1 - seq(0.01, 0.99, by = 0.01)) /
+                (seq(0.01, 0.99, by = 0.01))
+          )
+        )
       hover_text_treat_none <- "<b>Treat None</b><br>Interventions Avoided (per 100): {round(y, digits = 3)}<br>Probability Threshold: {x}<br>Odds of Prob. Threshold: 1:{round((1 - x) / x, digits = 2)}"
     }
 
@@ -1264,57 +1421,63 @@ create_reference_lines_data <- function(curve, prevalence,
     ) |>
       dplyr::mutate(
         text = dplyr::case_when(
-          reference_group == "reference_line" ~ glue::glue(hover_text_treat_all),
+          reference_group == "reference_line" ~ glue::glue(
+            hover_text_treat_all
+          ),
           TRUE ~ glue::glue(hover_text_treat_none)
         ),
-        text = stringr::str_replace(.data$text, "reference_line_treat_none_", "")
+        text = stringr::str_replace(
+          .data$text,
+          "reference_line_treat_none_",
+          ""
+        )
       ) |>
       dplyr::filter(.data$x >= min_p_threshold, .data$x <= max_p_threshold)
   }
-
 
   reference_lines_data
 }
 
 
 return_perfect_prediction_gains_y_values <- function(prevalence) {
-  
   c(
     seq(0, 1, length.out = (100 * (round(prevalence, digits = 3)) + 1)),
     rep(1, (100 - 100 * round(prevalence, digits = 3)))
   )
-  
 }
 
 return_perfect_prediction_lift_y_values <- function(prevalence) {
-  
   if (prevalence == 0) {
-    
     rep(NaN, 100)
-    
   } else {
-
     c(
-      rep( round(1 / prevalence, digits = 3), 100 * round(prevalence, digits = 3)),
-      seq( round(1 / prevalence, digits = 3), 1, length.out = (100 - 100 * (round(prevalence, digits = 3))))
+      rep(
+        round(1 / prevalence, digits = 3),
+        100 * round(prevalence, digits = 3)
+      ),
+      seq(
+        round(1 / prevalence, digits = 3),
+        1,
+        length.out = (100 - 100 * (round(prevalence, digits = 3)))
+      )
     )
   }
-  
 }
 
 
-
-extract_axes_ranges <- function(performance_data_ready, curve,
-                                min_p_threshold,
-                                max_p_threshold) {
+extract_axes_ranges <- function(
+  performance_data_ready,
+  curve,
+  min_p_threshold,
+  max_p_threshold
+) {
   if (curve %in% c("lift")) {
     max_y_range <- max(c(1, performance_data_ready$y), na.rm = TRUE)
   }
-  
+
   if (curve %in% c("decision", "interventions avoided")) {
     max_y_range <- max(performance_data_ready$y, na.rm = TRUE)
   }
-  
 
   if (curve %in% c("decision", "interventions avoided")) {
     min_x_range <- min_p_threshold
@@ -1323,14 +1486,11 @@ extract_axes_ranges <- function(performance_data_ready, curve,
     min_y_range <- min(c(performance_data_ready$y), 0)
   }
 
-
-
   if (curve == "roc") {
     curve_axis_range <- list(xaxis = c(0, 1), yaxis = c(0, 1))
   }
   if (curve == "lift") {
     curve_axis_range <- list(xaxis = c(0, 1), yaxis = c(0, max_y_range))
-    
   }
   if (curve == "precision recall") {
     curve_axis_range <- list(xaxis = c(0, 1), yaxis = c(0, 1))
@@ -1374,64 +1534,69 @@ extend_axis_ranges <- function(axis_range, extand_range_by = 1.1) {
 
 
 return_treat_all_y_values <- function(prevalence) {
-  c(prevalence - (1 - unique(prevalence)) *
-    (seq(0, 0.99, by = 0.01)) / (1 - seq(0, 0.99, by = 0.01)))
+  c(
+    prevalence -
+      (1 - unique(prevalence)) *
+        (seq(0, 0.99, by = 0.01)) /
+        (1 - seq(0, 0.99, by = 0.01))
+  )
 }
 
 return_treat_none_y_values <- function(prevalence) {
-  c(1 - prevalence - (unique(prevalence)) *
-    (1 - seq(0.01, 0.99, by = 0.01)) / (seq(0.01, 0.99, by = 0.01)))
+  c(
+    1 -
+      prevalence -
+      (unique(prevalence)) *
+        (1 - seq(0.01, 0.99, by = 0.01)) /
+        (seq(0.01, 0.99, by = 0.01))
+  )
 }
 
 
 prepare_performance_data_for_interactive_marker <- function(
-    performance_data_ready_for_curve, perf_dat_type) {
-  
-  
+  performance_data_ready_for_curve,
+  perf_dat_type
+) {
   performance_data_for_interactive_marker <- performance_data_ready_for_curve
-  
-  performance_data_for_interactive_marker$y[is.nan(performance_data_for_interactive_marker$y)] <- -100
-  performance_data_for_interactive_marker$x[is.nan(performance_data_for_interactive_marker$x)] <- -1
-  
-  if ( perf_dat_type %in% c("several models", "several populations") ) {
-    
-    performance_data_for_interactive_marker |> 
-      split(~reference_group) |> 
+
+  performance_data_for_interactive_marker$y[is.nan(
+    performance_data_for_interactive_marker$y
+  )] <- -100
+  performance_data_for_interactive_marker$x[is.nan(
+    performance_data_for_interactive_marker$x
+  )] <- -1
+
+  if (perf_dat_type %in% c("several models", "several populations")) {
+    performance_data_for_interactive_marker |>
+      split(~reference_group) |>
       purrr::map_df(check_zero_variance_for_sub_population)
-    
   } else {
-    
     performance_data_for_interactive_marker
-    
   }
-  
 }
 
 
-check_zero_variance_for_sub_population <- function(performance_data_sup_population) {
-  
-  if ( nrow(performance_data_sup_population) == 2 ) {
-    
+check_zero_variance_for_sub_population <- function(
+  performance_data_sup_population
+) {
+  if (nrow(performance_data_sup_population) == 2) {
     dplyr::bind_rows(
       performance_data_sup_population[1, ],
       data.frame(
         reference_group = rep(
-          unique(performance_data_sup_population$reference_group), 
-          1 / 0.01 - 1),
+          unique(performance_data_sup_population$reference_group),
+          1 / 0.01 - 1
+        ),
         x = seq(0 + 0.01, 1 - 0.01, by = 0.01),
         y = rep(-1, 1 / 0.01 - 1)
-      ) |> 
+      ) |>
         dplyr::mutate(
           stratified_by = x,
           text = NA
         ),
       performance_data_sup_population[2, ]
     )
-    
   } else {
-    
     performance_data_sup_population
-    
   }
-  
 }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -11,11 +11,11 @@ get_real_positives_from_performance_data <- function(performance_data,
                                                        "not important") {
   real_positives <- real_positives <- NULL
 
-  real_positives <- performance_data %>%
-    mutate(real_positives = TP + FN) %>%
-    dplyr::filter(ppcr == 1) %>%
-    dplyr::select(dplyr::any_of(c("model", "population", "real_positives"))) %>%
-    distinct() %>%
+  real_positives <- performance_data |>
+    mutate(real_positives = TP + FN) |>
+    dplyr::filter(ppcr == 1) |>
+    dplyr::select(dplyr::any_of(c("model", "population", "real_positives"))) |>
+    distinct() |>
     dplyr::pull(real_positives, name = 1)
 
   real_positives
@@ -34,10 +34,10 @@ get_prevalence_from_performance_data <- function(performance_data,
                                                    "not important") {
   PPV <- ppcr <- NULL
 
-  prevalence <- performance_data %>%
-    dplyr::filter(ppcr == 1) %>%
-    dplyr::select(dplyr::any_of(c("model", "population", "PPV"))) %>%
-    distinct() %>%
+  prevalence <- performance_data |>
+    dplyr::filter(ppcr == 1) |>
+    dplyr::select(dplyr::any_of(c("model", "population", "PPV"))) |>
+    distinct() |>
     dplyr::pull(PPV, name = 1)
 
   prevalence
@@ -58,13 +58,13 @@ get_n_from_performance_data <- function(performance_data,
 
   # print(performance_data)
 
-  real_positives <- performance_data %>%
-    dplyr::filter(ppcr == 1) %>%
+  real_positives <- performance_data |>
+    dplyr::filter(ppcr == 1) |>
     dplyr::select(dplyr::any_of(
       c("Model", "Population", "predicted_positives")
-    )) %>%
-    distinct() %>%
-    rename("n_obs" = predicted_positives) %>%
+    )) |>
+    distinct() |>
+    rename("n_obs" = predicted_positives) |>
     select(1, "n_obs")
   # dplyr::pull(predicted_positives , name = 1)
 
@@ -173,7 +173,7 @@ create_reference_lines_data_frame <- function(curve,
             linetype = "dotted"
           )
         }
-      ) %>%
+      ) |>
         bind_rows(
           data.frame(
             x = 0, xend = 1, y = 0, yend = 1, col = "grey",
@@ -186,18 +186,18 @@ create_reference_lines_data_frame <- function(curve,
         x = prevalence,
         y = 1,
         row.names = NULL
-      ) %>%
+      ) |>
         bind_rows(
           data.frame(
             population = rep(names(prevalence), each = 2),
             x = c(0, 1),
             y = c(0, 1)
           )
-        ) %>%
-        dplyr::arrange(population, x, y) %>%
+        ) |>
+        dplyr::arrange(population, x, y) |>
         dplyr::bind_rows(
           data.frame(population = "random", x = c(0, 1), y = c(0, 1))
-        ) %>%
+        ) |>
         dplyr::mutate(
           text = dplyr::case_when(
             population != "random" ~ glue::glue(
@@ -219,17 +219,17 @@ create_reference_lines_data_frame <- function(curve,
       )
     } else {
       if (length(prevalence) == 1) {
-        reference_lines_data_frame <- performance_data %>%
+        reference_lines_data_frame <- performance_data |>
           dplyr::mutate(
             population = "treat_all",
             x = probability_threshold,
             y = prevalence - (1 - prevalence) *
               (probability_threshold / (1 - probability_threshold))
-          ) %>%
-          dplyr::select(population, x, y) %>%
+          ) |>
+          dplyr::select(population, x, y) |>
           dplyr::bind_rows(
             data.frame(population = "treat_none", x = c(0, 1), y = c(0, 0))
-          ) %>%
+          ) |>
           dplyr::mutate(
             text = dplyr::case_when(
               population != "treat_none" ~ glue::glue("<b>NB Treat All:</b> \\
@@ -240,24 +240,24 @@ create_reference_lines_data_frame <- function(curve,
             )
           )
       } else {
-        reference_lines_data_frame <- performance_data %>%
+        reference_lines_data_frame <- performance_data |>
           dplyr::left_join(
-            data.frame(prevalence) %>%
+            data.frame(prevalence) |>
               tibble::rownames_to_column("population")
-          ) %>%
+          ) |>
           dplyr::mutate(
             x = probability_threshold,
             y = prevalence - (1 - prevalence) *
               (probability_threshold / (1 - probability_threshold)),
             linetype = "solid"
-          ) %>%
-          dplyr::select(population, x, y, linetype) %>%
+          ) |>
+          dplyr::select(population, x, y, linetype) |>
           dplyr::bind_rows(
             data.frame(
               population = "treat_none", x = c(0, 1), y = c(0, 0),
               linetype = "dotted"
             )
-          ) %>%
+          ) |>
           dplyr::mutate(
             text = dplyr::case_when(
               population != "treat_none" ~ glue::glue(
@@ -334,8 +334,11 @@ create_segment_for_reference_line <- function(reference_line) {
 
 add_reference_lines_to_ggplot <- function(ggplot_curve, reference_lines) {
   ggplot_curve$layers <- c(
-    purrr::map(reference_lines %>%
-      split(seq_len(nrow(.))), ~ create_segment_for_reference_line(.x)),
+    purrr::map(
+      reference_lines |>
+        split(seq_len(nrow(reference_lines))),
+      ~ create_segment_for_reference_line(.x)
+    ),
     ggplot_curve$layers
   )
   ggplot_curve
@@ -618,7 +621,6 @@ create_plotly_curve <- function(rtichoke_curve_list) {
 }
 
 
-
 #' Plot rtichoke curve
 #'
 #' @inheritParams create_roc_curve
@@ -772,10 +774,10 @@ extract_reference_groups_from_performance_data <- function(performance_data, per
 
 
 make_deciles_dat_new <- function(probs, reals) {
-  data.frame(probs, reals) %>%
-    dplyr::mutate(quintile = dplyr::ntile(probs, 10)) %>%
-    dplyr::group_by(quintile) %>%
-    dplyr::summarise(y = sum(reals) / n(), x = mean(probs), sum_reals = sum(reals), total_obs = n()) %>%
+  data.frame(probs, reals) |>
+    dplyr::mutate(quintile = dplyr::ntile(probs, 10)) |>
+    dplyr::group_by(quintile) |>
+    dplyr::summarise(y = sum(reals) / n(), x = mean(probs), sum_reals = sum(reals), total_obs = n()) |>
     dplyr::ungroup()
 }
 
@@ -818,10 +820,10 @@ prepare_performance_data_for_curve <- function(performance_data,
                                                perf_dat_type,
                                                min_p_threshold = 0,
                                                max_p_threshold = 1) {
-  performance_data %>%
-    {
+  performance_data |>
+    (\(data) {
       if (y_performance_metric == "NB_interventions_avoided") {
-        dplyr::mutate(.,
+        dplyr::mutate(data,
           N = TP + TN + FP + FN,
           prevalence = (TP + FN) / N,
           NB_intervention_all = prevalence - (1 - prevalence) *
@@ -830,17 +832,18 @@ prepare_performance_data_for_curve <- function(performance_data,
             ((1 - probability_threshold) / probability_threshold)
         )
       } else {
-        .
+        data
       }
-    } %>%
-    {
+    })() |>
+    (\(data) {
       if (stratified_by == "probability_threshold") {
-        dplyr::filter(., probability_threshold <= max_p_threshold) |>
+        data |>
+          dplyr::filter(probability_threshold <= max_p_threshold) |>
           dplyr::filter(probability_threshold >= min_p_threshold)
       } else {
-        .
+        data
       }
-    } |>
+    })() |>
     add_hover_text_to_performance_data_new(
       x_performance_metric, y_performance_metric, stratified_by, perf_dat_type
     ) |>
@@ -849,14 +852,14 @@ prepare_performance_data_for_curve <- function(performance_data,
       y_performance_metric,
       stratified_by,
       perf_dat_type
-    ) %>%
-    {
+    ) |>
+    (\(data) {
       if (y_performance_metric %in% c("NB", "NB_interventions_avoided")) {
-        dplyr::filter(., !is.nan(y))
+        dplyr::filter(data, !is.nan(y))
       } else {
-        .
+        data
       }
-    }
+    })()
 }
 
 
@@ -872,23 +875,17 @@ add_hover_text_to_performance_data_new <- function(performance_data,
     make_two_performance_metrics_bold(
       performance_metric_x,
       performance_metric_y
-    ) %>%
-    {
-      if (perf_dat_type == "several models") {
-        add_models_for_text_for_hover_new(.)
-      } else {
-        .
-      }
-    } %>%
-    {
-      if (perf_dat_type == "several populations") {
-        add_population_for_text_for_hover_new(.)
-      } else {
-        .
-      }
-    }
+    )
 
-  performance_data %>%
+  if (perf_dat_type == "several models") {
+    hover_text <- add_models_for_text_for_hover_new(hover_text)
+  }
+
+  if (perf_dat_type == "several populations") {
+    hover_text <- add_population_for_text_for_hover_new(hover_text)
+  }
+
+  performance_data |>
     dplyr::mutate(
       dplyr::across(where(is.numeric), round, 3),
       text = glue::glue(hover_text),

--- a/R/lift.R
+++ b/R/lift.R
@@ -74,23 +74,37 @@
 #'   stratified_by = "ppcr"
 #' )
 #' }
-create_lift_curve <- function(probs, reals, by = 0.01,
-                              stratified_by = "probability_threshold",
-                              chosen_threshold = NA,
-                              interactive = TRUE,
-                              color_values = c(
-                                "#1b9e77", "#d95f02",
-                                "#7570b3", "#e7298a",
-                                "#07004D", "#E6AB02",
-                                "#FE5F55", "#54494B",
-                                "#006E90", "#BC96E6",
-                                "#52050A", "#1F271B",
-                                "#BE7C4D", "#63768D",
-                                "#08A045", "#320A28",
-                                "#82FF9E", "#2176FF",
-                                "#D1603D", "#585123"
-                              ),
-                              size = NULL) {
+create_lift_curve <- function(
+  probs,
+  reals,
+  by = 0.01,
+  stratified_by = "probability_threshold",
+  chosen_threshold = NA,
+  interactive = TRUE,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  ),
+  size = NULL
+) {
   if (!is.na(chosen_threshold)) {
     check_chosen_threshold_input(chosen_threshold)
   }
@@ -139,22 +153,34 @@ create_lift_curve <- function(probs, reals, by = 0.01,
 #' }
 #'
 #' @export
-plot_lift_curve <- function(performance_data,
-                            chosen_threshold = NA,
-                            interactive = TRUE,
-                            color_values = c(
-                              "#1b9e77", "#d95f02",
-                              "#7570b3", "#e7298a",
-                              "#07004D", "#E6AB02",
-                              "#FE5F55", "#54494B",
-                              "#006E90", "#BC96E6",
-                              "#52050A", "#1F271B",
-                              "#BE7C4D", "#63768D",
-                              "#08A045", "#320A28",
-                              "#82FF9E", "#2176FF",
-                              "#D1603D", "#585123"
-                            ),
-                            size = NULL) {
+plot_lift_curve <- function(
+  performance_data,
+  chosen_threshold = NA,
+  interactive = TRUE,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  ),
+  size = NULL
+) {
   rtichoke_curve_list <- performance_data |>
     create_rtichoke_curve_list("lift", size = size, color_values = color_values)
 
@@ -167,8 +193,7 @@ plot_lift_curve <- function(performance_data,
   )
 
   perf_dat_type <- check_performance_data_type_for_plotly(
-    performance_data =
-      performance_data
+    performance_data = performance_data
   )
   prevalence <- get_prevalence_from_performance_data(
     performance_data,

--- a/R/lift.R
+++ b/R/lift.R
@@ -43,32 +43,32 @@
 #'
 #' create_lift_curve(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   )
 #' )
 #'
 #' create_lift_curve(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   ),
 #'   stratified_by = "ppcr"
@@ -100,7 +100,7 @@ create_lift_curve <- function(probs, reals, by = 0.01,
     reals = reals,
     by = by,
     stratified_by = stratified_by
-  ) %>%
+  ) |>
     plot_lift_curve(
       chosen_threshold = chosen_threshold,
       interactive = interactive,
@@ -119,22 +119,22 @@ create_lift_curve <- function(probs, reals, by = 0.01,
 #' @examples
 #' \dontrun{
 #'
-#' one_pop_one_model %>%
+#' one_pop_one_model |>
 #'   plot_lift_curve()
 #'
-#' one_pop_one_model_by_ppcr %>%
+#' one_pop_one_model_by_ppcr |>
 #'   plot_lift_curve()
 #'
-#' multiple_models %>%
+#' multiple_models |>
 #'   plot_lift_curve()
 #'
-#' multiple_models_by_ppcr %>%
+#' multiple_models_by_ppcr |>
 #'   plot_lift_curve()
 #'
-#' multiple_populations %>%
+#' multiple_populations |>
 #'   plot_lift_curve()
 #'
-#' multiple_populations_by_ppcr %>%
+#' multiple_populations_by_ppcr |>
 #'   plot_lift_curve()
 #' }
 #'
@@ -178,9 +178,9 @@ plot_lift_curve <- function(performance_data,
   if (interactive == FALSE) {
     reference_lines <- create_reference_lines_data_frame("lift")
 
-    lift_curve <- performance_data %>%
-      create_ggplot_for_performance_metrics("ppcr", "lift", color_values) %>%
-      add_reference_lines_to_ggplot(reference_lines) %>%
+    lift_curve <- performance_data |>
+      create_ggplot_for_performance_metrics("ppcr", "lift", color_values) |>
+      add_reference_lines_to_ggplot(reference_lines) |>
       set_lift_curve_limits() +
       ggplot2::xlab("Predicted Positives (Rate)") +
       ggplot2::ylab("Lift")

--- a/R/performance_table.R
+++ b/R/performance_table.R
@@ -47,32 +47,32 @@
 #'
 #' create_performance_table(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   )
 #' )
 #'
 #' create_performance_table(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   ),
 #'   stratified_by = "ppcr"
@@ -100,7 +100,7 @@ create_performance_table <- function(probs,
     reals = reals,
     by = by,
     stratified_by = stratified_by
-  ) %>%
+  ) |>
     render_performance_table(
       color_values = color_values,
       output_type = output_type
@@ -118,22 +118,22 @@ create_performance_table <- function(probs,
 #' @examples
 #' \dontrun{
 #'
-#' one_pop_one_model %>%
+#' one_pop_one_model |>
 #'   render_performance_table()
 #'
-#' one_pop_one_model_by_ppcr %>%
+#' one_pop_one_model_by_ppcr |>
 #'   render_performance_table()
 #'
-#' multiple_models %>%
+#' multiple_models |>
 #'   render_performance_table()
 #'
-#' multiple_models_by_ppcr %>%
+#' multiple_models_by_ppcr |>
 #'   render_performance_table()
 #'
-#' multiple_populations %>%
+#' multiple_populations |>
 #'   render_performance_table()
 #'
-#' multiple_populations_by_ppcr %>%
+#' multiple_populations_by_ppcr |>
 #'   render_performance_table()
 #' }
 #'
@@ -173,19 +173,19 @@ render_performance_table <- function(performance_data,
   
   
   if (output_type == "gt") {
-    performance_data %>%
-      prepare_performance_data_for_gt(main_slider) %>%
+    performance_data |>
+      prepare_performance_data_for_gt(main_slider) |>
       render_and_format_gt(main_slider, perf_dat_type, prevalence, color_values)
   }
 
   if (output_type == "reactable") {
-    performance_data_reactable <- performance_data %>%
+    performance_data_reactable <- performance_data |>
       dplyr::select(any_of(
         c(
           "probability_threshold", "model", "population", "sensitivity", "specificity",
           "PPV", "NPV", "lift", "predicted_positives", "NB", "ppcr"
         )
-      )) %>%
+      )) |>
       dplyr::rename(any_of(c(
         "Model" = "model",
         "Population" = "population",
@@ -194,23 +194,23 @@ render_performance_table <- function(performance_data,
 
 
     if (stratified_by != "probability_threshold") {
-      performance_data_reactable <- performance_data_reactable %>%
+      performance_data_reactable <- performance_data_reactable |>
         dplyr::relocate(.data$predicted_positives,
                         .data$ppcr,
           .after = Threshold
-        ) %>%
-        dplyr::arrange(.data$ppcr) %>%
-        dplyr::select(-.data$Threshold) %>%
+        ) |>
+        dplyr::arrange(.data$ppcr) |>
+        dplyr::select(-.data$Threshold) |>
         mutate(rank = dplyr::dense_rank(.data$ppcr))
     } else {
-      performance_data_reactable <- performance_data_reactable %>%
-        dplyr::arrange(.data$Threshold) %>%
+      performance_data_reactable <- performance_data_reactable |>
+        dplyr::arrange(.data$Threshold) |>
         mutate(rank = dplyr::dense_rank(.data$Threshold))
     }
 
 
     if ("Model" %in% names(performance_data_reactable)) {
-      performance_data_reactable <- performance_data_reactable %>%
+      performance_data_reactable <- performance_data_reactable |>
         dplyr::mutate(
           Model = forcats::fct_inorder(
             factor(.data$Model)
@@ -222,7 +222,7 @@ render_performance_table <- function(performance_data,
           key_values =
             factor(.data$key_values,
               labels = as.character(seq_len(
-                length(unique(performance_data_reactable %>%
+                length(unique(performance_data_reactable |>
                   dplyr::pull(Model)))
               ))
             )
@@ -230,7 +230,7 @@ render_performance_table <- function(performance_data,
     }
 
     if ("Population" %in% names(performance_data_reactable)) {
-      performance_data_reactable <- performance_data_reactable %>%
+      performance_data_reactable <- performance_data_reactable |>
         dplyr::mutate(
           Population = forcats::fct_inorder(
             factor(.data$Population)
@@ -242,14 +242,14 @@ render_performance_table <- function(performance_data,
           key_values =
             factor(.data$key_values,
               labels = as.character(seq_len(
-                length(unique(performance_data_reactable %>%
+                length(unique(performance_data_reactable |>
                   dplyr::pull(Population)))
               ))
             )
         )
     }
 
-    confusion_matrix_list <- performance_data %>%
+    confusion_matrix_list <- performance_data |>
       create_conf_mat_list(stratified_by = stratified_by)
 
     interactive_data <- SharedData$new(performance_data_reactable)
@@ -265,7 +265,7 @@ render_performance_table <- function(performance_data,
       ))
     }
 
-    interactive_data_reactable <- interactive_data %>%
+    interactive_data_reactable <- interactive_data |>
       reactable::reactable(
         showSortIcon = FALSE,
         borderless = FALSE,
@@ -390,8 +390,7 @@ render_performance_table <- function(performance_data,
         details = function(index) {
           htmltools::div(
             style = "padding: 16px",
-            confusion_matrix_list %>%
-              .[[index]]
+            confusion_matrix_list[[index]]
           )
         }
       )
@@ -438,7 +437,7 @@ render_performance_table <- function(performance_data,
           interactive_data,
           ~key_values,
           inline = TRUE,
-          labels_values = unique(performance_data_reactable %>%
+          labels_values = unique(performance_data_reactable |>
             pull(main_label))
         ),
         crosstalk::filter_slider(
@@ -461,32 +460,32 @@ render_performance_table <- function(performance_data,
 #' @inheritParams plot_roc_curve
 prepare_performance_data_for_gt <- function(performance_data,
                                             main_slider) {
-  performance_data_ready_for_gt <- performance_data %>%
-    replace_nan_with_na() %>%
+  performance_data_ready_for_gt <- performance_data |>
+    replace_nan_with_na() |>
     dplyr::rename(any_of(c(
       "Model" = "model",
       "Population" = "population",
       "Threshold" = "probability_threshold"
-    ))) %>%
+    ))) |>
     add_colors_to_performance_dat()
 
 
 
   if (stratified_by != "probability_threshold") {
-    performance_data_ready_for_gt <- performance_data_ready_for_gt %>%
+    performance_data_ready_for_gt <- performance_data_ready_for_gt |>
       dplyr::relocate(.data$plot_predicted_positives,
         .after = .data$Threshold
-      ) %>%
-      dplyr::arrange(.data$ppcr) %>%
-      dplyr::select(-.data$Threshold) %>%
+      ) |>
+      dplyr::arrange(.data$ppcr) |>
+      dplyr::select(-.data$Threshold) |>
       mutate(rank = dplyr::dense_rank(.data$ppcr))
   } else {
-    performance_data_ready_for_gt <- performance_data_ready_for_gt %>%
-      dplyr::arrange(Threshold) %>%
+    performance_data_ready_for_gt <- performance_data_ready_for_gt |>
+      dplyr::arrange(Threshold) |>
       mutate(rank = dplyr::dense_rank(Threshold))
   }
 
-  performance_data_ready_for_gt %>%
+  performance_data_ready_for_gt |>
     dplyr::select(-c(
       .data$ppcr,
       .data$predicted_positives,
@@ -507,58 +506,58 @@ render_and_format_gt <- function(performance_data,
                                  perf_dat_type,
                                  prevalence,
                                  color_values) {
-  performance_data %>%
-    gt::gt() %>%
-    gt::cols_hide(rank) %>%
+  performance_data |>
+    gt::gt() |>
+    gt::cols_hide(rank) |>
     gt::fmt_missing(
       columns = dplyr::everything(),
       rows = dplyr::everything(),
       missing_text = ""
-    ) %>%
+    ) |>
     gt::cols_align(
       align = "left",
       columns = dplyr::everything()
-    ) %>%
+    ) |>
     gt::cols_align(
       align = "center",
       columns = NB
-    ) %>%
+    ) |>
     gt::cols_width(
       c(
         TP, TN, FP, FN,
         sensitivity, lift, specificity, PPV, NPV, NB,
         plot_predicted_positives
       ) ~ px(100)
-    ) %>%
+    ) |>
     gt::tab_spanner(
       label = "Confusion Matrix",
       columns = c(
         TP, FP, TN, FN,
         sensitivity, lift, specificity, PPV, NPV, NB
       )
-    ) %>%
+    ) |>
     gt::tab_spanner(
       label = "Performance Metrics",
       columns = c(
         sensitivity, lift, specificity,
         PPV, NPV, NB
       )
-    ) %>%
+    ) |>
     gt::cols_label(
       sensitivity = "Sens",
       lift = "Lift",
       specificity = "Spec",
       plot_predicted_positives = "Predicted Positives"
-    ) %>%
+    ) |>
     # gt::tab_options(
     #   table.background.color = "#FFFBF3"
-    # ) %>%
+    # ) |>
     # gt::tab_header(
     #   title = gt::md(creating_title_for_gt(main_slider)),
     #   subtitle = gt::md(creating_subtitle_for_gt(perf_dat_type,
     #                                       prevalence = prevalence,
     #                                       color_values = color_values))
-    # ) %>%
+    # ) |>
     add_zebra_colors_to_gt_table(perf_dat_type %in% c(
       "several models",
       "several populations"
@@ -575,7 +574,7 @@ render_and_format_gt <- function(performance_data,
 add_zebra_colors_to_gt_table <- function(performance_table,
                                          add_zebra_colors) {
   if (add_zebra_colors == TRUE) {
-    performance_table %>%
+    performance_table |>
       gt::tab_style(
         style = gt::cell_fill(color = "#f5f1f1"),
         locations = gt::cells_body(
@@ -623,10 +622,10 @@ creating_subtitle_for_gt <- function(perf_dat_type,
   if (perf_dat_type == "several models") {
     color_values <- color_values[seq_len(length(prevalence))]
 
-    subtitle_for_gt <- prevalence %>%
-      names() %>%
-      purrr::map2(color_values, add_html_color_to_model_for_subtitle) %>%
-      glue::glue_collapse(", ", last = " and ") %>%
+    subtitle_for_gt <- prevalence |>
+      names() |>
+      purrr::map2(color_values, add_html_color_to_model_for_subtitle) |>
+      glue::glue_collapse(", ", last = " and ") |>
       glue::glue(" (Prevalnce: {round(prevalence[1], digits = 2)})")
   }
 
@@ -640,7 +639,7 @@ creating_subtitle_for_gt <- function(perf_dat_type,
         prevalence
       ),
       create_subtitle_for_one_population
-    ) %>%
+    ) |>
       glue::glue_collapse(", ", last = " and ")
   }
 

--- a/R/performance_table.R
+++ b/R/performance_table.R
@@ -1,7 +1,5 @@
 # Performance Table ----------------------------------------------------------
 
-
-
 #' Performance Table
 #'
 #' Create a Performance Table
@@ -78,23 +76,35 @@
 #'   stratified_by = "ppcr"
 #' )
 #' }
-create_performance_table <- function(probs,
-                                     reals,
-                                     by = 0.01,
-                                     stratified_by = "probability_threshold",
-                                     color_values = c(
-                                       "#1b9e77", "#d95f02",
-                                       "#7570b3", "#e7298a",
-                                       "#07004D", "#E6AB02",
-                                       "#FE5F55", "#54494B",
-                                       "#006E90", "#BC96E6",
-                                       "#52050A", "#1F271B",
-                                       "#BE7C4D", "#63768D",
-                                       "#08A045", "#320A28",
-                                       "#82FF9E", "#2176FF",
-                                       "#D1603D", "#585123"
-                                     ),
-                                     output_type = "reactable") {
+create_performance_table <- function(
+  probs,
+  reals,
+  by = 0.01,
+  stratified_by = "probability_threshold",
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  ),
+  output_type = "reactable"
+) {
   prepare_performance_data(
     probs = probs,
     reals = reals,
@@ -138,21 +148,33 @@ create_performance_table <- function(probs,
 #' }
 #'
 #' @export
-render_performance_table <- function(performance_data,
-                                     chosen_threshold = NA,
-                                     output_type = "reactable",
-                                     color_values = c(
-                                       "#1b9e77", "#d95f02",
-                                       "#7570b3", "#e7298a",
-                                       "#07004D", "#E6AB02",
-                                       "#FE5F55", "#54494B",
-                                       "#006E90", "#BC96E6",
-                                       "#52050A", "#1F271B",
-                                       "#BE7C4D", "#63768D",
-                                       "#08A045", "#320A28",
-                                       "#82FF9E", "#2176FF",
-                                       "#D1603D", "#585123"
-                                     )) {
+render_performance_table <- function(
+  performance_data,
+  chosen_threshold = NA,
+  output_type = "reactable",
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  )
+) {
   stratified_by <- check_performance_data_stratification(
     performance_data
   )
@@ -162,16 +184,18 @@ render_performance_table <- function(performance_data,
   )
 
   prevalence <- get_prevalence_from_performance_data(
-    performance_data, perf_dat_type
+    performance_data,
+    perf_dat_type
   )
-  
+
   group_colors_vec <- performance_data |>
-    extract_reference_groups_from_performance_data(perf_dat_type)  |>
+    extract_reference_groups_from_performance_data(perf_dat_type) |>
     create_reference_group_color_vector(
-      perf_dat_type, color_values = color_values) |> 
+      perf_dat_type,
+      color_values = color_values
+    ) |>
     unlist()
-  
-  
+
   if (output_type == "gt") {
     performance_data |>
       prepare_performance_data_for_gt(main_slider) |>
@@ -182,8 +206,17 @@ render_performance_table <- function(performance_data,
     performance_data_reactable <- performance_data |>
       dplyr::select(any_of(
         c(
-          "probability_threshold", "model", "population", "sensitivity", "specificity",
-          "PPV", "NPV", "lift", "predicted_positives", "NB", "ppcr"
+          "probability_threshold",
+          "model",
+          "population",
+          "sensitivity",
+          "specificity",
+          "PPV",
+          "NPV",
+          "lift",
+          "predicted_positives",
+          "NB",
+          "ppcr"
         )
       )) |>
       dplyr::rename(any_of(c(
@@ -192,11 +225,11 @@ render_performance_table <- function(performance_data,
         "Threshold" = "probability_threshold"
       )))
 
-
     if (stratified_by != "probability_threshold") {
       performance_data_reactable <- performance_data_reactable |>
-        dplyr::relocate(.data$predicted_positives,
-                        .data$ppcr,
+        dplyr::relocate(
+          .data$predicted_positives,
+          .data$ppcr,
           .after = Threshold
         ) |>
         dplyr::arrange(.data$ppcr) |>
@@ -208,24 +241,24 @@ render_performance_table <- function(performance_data,
         mutate(rank = dplyr::dense_rank(.data$Threshold))
     }
 
-
     if ("Model" %in% names(performance_data_reactable)) {
       performance_data_reactable <- performance_data_reactable |>
         dplyr::mutate(
           Model = forcats::fct_inorder(
             factor(.data$Model)
           ),
-          key_values =
-            forcats::fct_inorder(
-              factor(.data$Model)
-            ),
-          key_values =
-            factor(.data$key_values,
-              labels = as.character(seq_len(
-                length(unique(performance_data_reactable |>
-                  dplyr::pull(Model)))
+          key_values = forcats::fct_inorder(
+            factor(.data$Model)
+          ),
+          key_values = factor(
+            .data$key_values,
+            labels = as.character(seq_len(
+              length(unique(
+                performance_data_reactable |>
+                  dplyr::pull(Model)
               ))
-            )
+            ))
+          )
         )
     }
 
@@ -235,17 +268,18 @@ render_performance_table <- function(performance_data,
           Population = forcats::fct_inorder(
             factor(.data$Population)
           ),
-          key_values =
-            forcats::fct_inorder(
-              factor(.data$Population)
-            ),
-          key_values =
-            factor(.data$key_values,
-              labels = as.character(seq_len(
-                length(unique(performance_data_reactable |>
-                  dplyr::pull(Population)))
+          key_values = forcats::fct_inorder(
+            factor(.data$Population)
+          ),
+          key_values = factor(
+            .data$key_values,
+            labels = as.character(seq_len(
+              length(unique(
+                performance_data_reactable |>
+                  dplyr::pull(Population)
               ))
-            )
+            ))
+          )
         )
     }
 
@@ -255,14 +289,16 @@ render_performance_table <- function(performance_data,
     interactive_data <- SharedData$new(performance_data_reactable)
 
     status_badge <- function(color = "#aaa", width = "9px", height = width) {
-      span(style = list(
-        display = "inline-block",
-        marginRight = "8px",
-        width = width,
-        height = height,
-        backgroundColor = color,
-        borderRadius = "50%"
-      ))
+      span(
+        style = list(
+          display = "inline-block",
+          marginRight = "8px",
+          width = width,
+          height = height,
+          backgroundColor = color,
+          borderRadius = "50%"
+        )
+      )
     }
 
     interactive_data_reactable <- interactive_data |>
@@ -276,7 +312,8 @@ render_performance_table <- function(performance_data,
           rank = reactable::colDef(show = FALSE),
           Threshold = reactable::colDef(
             name = "Probability Threshold",
-            style = reactable::JS("function(rowInfo, colInfo, state) {
+            style = reactable::JS(
+              "function(rowInfo, colInfo, state) {
         const firstSorted = state.sorted[0]
         // Merge cells if unsorted or sorting by school
         if (!firstSorted || firstSorted.id === 'Threshold') {
@@ -285,45 +322,55 @@ render_performance_table <- function(performance_data,
             return { visibility: 'hidden' }
           }
         }
-      }")
+      }"
+            )
           ),
           sensitivity = reactable::colDef(
-            name = "Sens", style = function(value) {
+            name = "Sens",
+            style = function(value) {
               bar_style_perf(width = value)
             },
             format = reactable::colFormat(digits = 2)
           ),
           specificity = reactable::colDef(
-            name = "Spec", style = function(value) {
+            name = "Spec",
+            style = function(value) {
               bar_style_perf(width = value)
-            }, format = reactable::colFormat(digits = 2)
+            },
+            format = reactable::colFormat(digits = 2)
           ),
           PPV = reactable::colDef(
-            name = "PPV", style = function(value) {
+            name = "PPV",
+            style = function(value) {
               bar_style_perf(width = value)
-            }, format = reactable::colFormat(digits = 2)
+            },
+            format = reactable::colFormat(digits = 2)
           ),
           NPV = reactable::colDef(
-            name = "NPV", style = function(value) {
+            name = "NPV",
+            style = function(value) {
               bar_style_perf(width = value)
-            }, format = reactable::colFormat(digits = 2)
+            },
+            format = reactable::colFormat(digits = 2)
           ),
           lift = reactable::colDef(
-            name = "Lift", style = function(value) {
-              bar_style_perf(width = value /
-                max(performance_data_reactable$lift,
-                  na.rm = TRUE
-                ))
-            }, format = reactable::colFormat(digits = 2)
+            name = "Lift",
+            style = function(value) {
+              bar_style_perf(
+                width = value /
+                  max(performance_data_reactable$lift, na.rm = TRUE)
+              )
+            },
+            format = reactable::colFormat(digits = 2)
           ),
           NB = reactable::colDef(
             name = "Net Benefit",
             format = reactable::colFormat(digits = 2),
             style = function(value) {
-              bar_style_nb_reactable(width = value /
-                max(abs(performance_data_reactable$NB),
-                  na.rm = TRUE
-                ))
+              bar_style_nb_reactable(
+                width = value /
+                  max(abs(performance_data_reactable$NB), na.rm = TRUE)
+              )
             }
           ),
           ppcr = reactable::colDef(
@@ -331,8 +378,10 @@ render_performance_table <- function(performance_data,
             cell = function(value, index) {
               predicted_positives <-
                 performance_data_reactable$predicted_positives[index]
-              glue::glue("{predicted_positives} \\
-                         ({round(value, digits = 2) * 100}%) ")
+              glue::glue(
+                "{predicted_positives} \\
+                         ({round(value, digits = 2) * 100}%) "
+              )
             },
             style = function(value) {
               bar_style_perf(width = value, color = "lightgrey")
@@ -344,7 +393,6 @@ render_performance_table <- function(performance_data,
           Population = reactable::colDef(
             show = TRUE,
             cell = function(value) {
-
               color <- group_colors_vec[[as.character(value)]]
 
               badge <- status_badge(color = color)
@@ -354,9 +402,8 @@ render_performance_table <- function(performance_data,
           Model = reactable::colDef(
             show = TRUE,
             cell = function(value) {
-              
               color <- group_colors_vec[[as.character(value)]]
-              
+
               badge <- status_badge(color = color)
               tagList(badge, value)
             }
@@ -368,20 +415,21 @@ render_performance_table <- function(performance_data,
         columnGroups = list(
           reactable::colGroup(
             name = "Performance Metrics",
-            columns = (if (
-              stratified_by == "probability_threshold"
-            ) {
+            columns = (if (stratified_by == "probability_threshold") {
               c(
                 "sensitivity",
                 "specificity",
-                "PPV", "NPV",
-                "lift", "NB"
+                "PPV",
+                "NPV",
+                "lift",
+                "NB"
               )
             } else {
               c(
                 "sensitivity",
                 "specificity",
-                "PPV", "NPV",
+                "PPV",
+                "NPV",
                 "lift"
               )
             })
@@ -409,9 +457,10 @@ render_performance_table <- function(performance_data,
       slider_label <- "Probability Threshold"
     }
 
-
-    if (perf_dat_type %in%
-      c("one model", "one model with model column")) {
+    if (
+      perf_dat_type %in%
+        c("one model", "one model with model column")
+    ) {
       crosstalk::bscols(
         widths = c(6, 12),
         crosstalk::filter_slider(
@@ -429,16 +478,18 @@ render_performance_table <- function(performance_data,
         main_label <- "Population"
       }
 
-
       crosstalk::bscols(
         widths = c(12, 6, 12),
-        filter_checkbox_rtichoke("population",
+        filter_checkbox_rtichoke(
+          "population",
           main_label,
           interactive_data,
           ~key_values,
           inline = TRUE,
-          labels_values = unique(performance_data_reactable |>
-            pull(main_label))
+          labels_values = unique(
+            performance_data_reactable |>
+              pull(main_label)
+          )
         ),
         crosstalk::filter_slider(
           "Propability Threshold",
@@ -453,13 +504,11 @@ render_performance_table <- function(performance_data,
 }
 
 
-
 #' Preparing Performance Data for gt
 #'
 #' @keywords internal
 #' @inheritParams plot_roc_curve
-prepare_performance_data_for_gt <- function(performance_data,
-                                            main_slider) {
+prepare_performance_data_for_gt <- function(performance_data, main_slider) {
   performance_data_ready_for_gt <- performance_data |>
     replace_nan_with_na() |>
     dplyr::rename(any_of(c(
@@ -469,11 +518,10 @@ prepare_performance_data_for_gt <- function(performance_data,
     ))) |>
     add_colors_to_performance_dat()
 
-
-
   if (stratified_by != "probability_threshold") {
     performance_data_ready_for_gt <- performance_data_ready_for_gt |>
-      dplyr::relocate(.data$plot_predicted_positives,
+      dplyr::relocate(
+        .data$plot_predicted_positives,
         .after = .data$Threshold
       ) |>
       dplyr::arrange(.data$ppcr) |>
@@ -486,12 +534,14 @@ prepare_performance_data_for_gt <- function(performance_data,
   }
 
   performance_data_ready_for_gt |>
-    dplyr::select(-c(
-      .data$ppcr,
-      .data$predicted_positives,
-      .data$display_predicted_postivies,
-      .data$FPR
-    ))
+    dplyr::select(
+      -c(
+        .data$ppcr,
+        .data$predicted_positives,
+        .data$display_predicted_postivies,
+        .data$FPR
+      )
+    )
 }
 
 
@@ -501,11 +551,13 @@ prepare_performance_data_for_gt <- function(performance_data,
 #' @inheritParams plot_roc_curve
 #' @param prevalence the prevalence of the populations
 
-render_and_format_gt <- function(performance_data,
-                                 main_slider,
-                                 perf_dat_type,
-                                 prevalence,
-                                 color_values) {
+render_and_format_gt <- function(
+  performance_data,
+  main_slider,
+  perf_dat_type,
+  prevalence,
+  color_values
+) {
   performance_data |>
     gt::gt() |>
     gt::cols_hide(rank) |>
@@ -524,23 +576,43 @@ render_and_format_gt <- function(performance_data,
     ) |>
     gt::cols_width(
       c(
-        TP, TN, FP, FN,
-        sensitivity, lift, specificity, PPV, NPV, NB,
+        TP,
+        TN,
+        FP,
+        FN,
+        sensitivity,
+        lift,
+        specificity,
+        PPV,
+        NPV,
+        NB,
         plot_predicted_positives
       ) ~ px(100)
     ) |>
     gt::tab_spanner(
       label = "Confusion Matrix",
       columns = c(
-        TP, FP, TN, FN,
-        sensitivity, lift, specificity, PPV, NPV, NB
+        TP,
+        FP,
+        TN,
+        FN,
+        sensitivity,
+        lift,
+        specificity,
+        PPV,
+        NPV,
+        NB
       )
     ) |>
     gt::tab_spanner(
       label = "Performance Metrics",
       columns = c(
-        sensitivity, lift, specificity,
-        PPV, NPV, NB
+        sensitivity,
+        lift,
+        specificity,
+        PPV,
+        NPV,
+        NB
       )
     ) |>
     gt::cols_label(
@@ -558,10 +630,13 @@ render_and_format_gt <- function(performance_data,
     #                                       prevalence = prevalence,
     #                                       color_values = color_values))
     # ) |>
-    add_zebra_colors_to_gt_table(perf_dat_type %in% c(
-      "several models",
-      "several populations"
-    ))
+    add_zebra_colors_to_gt_table(
+      perf_dat_type %in%
+        c(
+          "several models",
+          "several populations"
+        )
+    )
 }
 
 
@@ -571,8 +646,7 @@ render_and_format_gt <- function(performance_data,
 #' @param add_zebra_colors add zebra colors or keep table as it is (FALSE)
 #'
 #' @keywords internal
-add_zebra_colors_to_gt_table <- function(performance_table,
-                                         add_zebra_colors) {
+add_zebra_colors_to_gt_table <- function(performance_table, add_zebra_colors) {
   if (add_zebra_colors == TRUE) {
     performance_table |>
       gt::tab_style(
@@ -599,15 +673,16 @@ creating_title_for_gt <- function(main_slider) {
 }
 
 
-
 #' Creating Subtitle for gt performance table
 #'
 #' @keywords internal
 #' @inheritParams plot_roc_curve
 #' @param models_names the names of the different models
-creating_subtitle_for_gt <- function(perf_dat_type,
-                                     color_values = NA,
-                                     prevalence = NA) {
+creating_subtitle_for_gt <- function(
+  perf_dat_type,
+  color_values = NA,
+  prevalence = NA
+) {
   if (perf_dat_type == "one model") {
     subtitle_for_gt <- glue::glue("Prevalence: {round(prevalence, digits = 2)}")
   }
@@ -643,12 +718,8 @@ creating_subtitle_for_gt <- function(perf_dat_type,
       glue::glue_collapse(", ", last = " and ")
   }
 
-
   subtitle_for_gt
 }
-
-
-
 
 
 #' Creating Subtitle for One Population
@@ -658,13 +729,17 @@ creating_subtitle_for_gt <- function(perf_dat_type,
 #' @param pop_prevalence the prevalence of the population
 #'
 #' @keywords internal
-create_subtitle_for_one_population <- function(pop_name,
-                                               pop_color,
-                                               pop_prevalence) {
-  glue::glue("<b><span style=\"color: \\
+create_subtitle_for_one_population <- function(
+  pop_name,
+  pop_color,
+  pop_prevalence
+) {
+  glue::glue(
+    "<b><span style=\"color: \\
              {pop_color};\">{pop_name}</span></b> \\
              population (Prevalence: \\
-             {round(pop_prevalence, digits = 2)})")
+             {round(pop_prevalence, digits = 2)})"
+  )
 }
 
 
@@ -674,12 +749,9 @@ create_subtitle_for_one_population <- function(pop_name,
 #' @param model_color the color of the model
 #'
 #' @keywords internal
-add_html_color_to_model_for_subtitle <- function(model_name,
-                                                 model_color) {
+add_html_color_to_model_for_subtitle <- function(model_name, model_color) {
   glue::glue("<b><span style=\"color: {model_color};\">{model_name}</span></b>")
 }
-
-
 
 
 #' Add background color
@@ -695,7 +767,8 @@ bar_style_perf <- function(width = 1, color = "lightgreen") {
   list(
     background = sprintf(
       "linear-gradient(90deg, %2$s %1$s, transparent %1$s)",
-      position, color
+      position,
+      color
     ),
     backgroundSize = "98% 88%",
     backgroundRepeat = "no-repeat",
@@ -709,9 +782,11 @@ bar_style_perf <- function(width = 1, color = "lightgreen") {
 #' @param The width of the background color
 #'
 #' @keywords internal
-bar_style_nb_reactable <- function(width = 1,
-                                   pos_fill = "lightgreen",
-                                   neg_fill = "pink") {
+bar_style_nb_reactable <- function(
+  width = 1,
+  pos_fill = "lightgreen",
+  neg_fill = "pink"
+) {
   if (is.na(width)) {
     width <- 0
   }
@@ -722,12 +797,14 @@ bar_style_nb_reactable <- function(width = 1,
   if (width >= 0) {
     background <- sprintf(
       "linear-gradient(90deg, transparent 50%%, %2$s 50%%, %2$s %1$s, transparent %1$s)",
-      position, pos_fill
+      position,
+      pos_fill
     )
   } else {
     background <- sprintf(
       "linear-gradient(90deg, transparent %1$s, %2$s %1$s, %2$s 50%%, transparent 50%%)",
-      position, neg_fill
+      position,
+      neg_fill
     )
   }
   list(

--- a/R/performance_table_gt_functions.R
+++ b/R/performance_table_gt_functions.R
@@ -7,11 +7,13 @@
 #' @param no_round no rounding
 #'
 #' @keywords internal
-bar_chart <- function(value,
-                      display,
-                      color = "red",
-                      digits = 0,
-                      no_round = FALSE) {
+bar_chart <- function(
+  value,
+  display,
+  color = "red",
+  digits = 0,
+  no_round = FALSE
+) {
   if (is.na(value) | is.nan(value)) {
     NA
   } else {
@@ -22,9 +24,11 @@ bar_chart <- function(value,
         format(nsmall = digits)
     }
 
-    glue::glue("<span style=\"display: inline-block;direction: ltr;
+    glue::glue(
+      "<span style=\"display: inline-block;direction: ltr;
              background-color: {color}; color: black;
-             width: {value}%\">{display_rounded}</span>") |>
+             width: {value}%\">{display_rounded}</span>"
+    ) |>
       as.character() |>
       gt::html()
   }
@@ -41,20 +45,24 @@ bar_style_nb <- function(width, display) {
 
     if (width <= 0) {
       fill <- "pink"
-      html_code <- glue::glue("<span style=\"display: \\
+      html_code <- glue::glue(
+        "<span style=\"display: \\
       inline-block; background: linear-gradient(90deg,
              transparent {position}, {fill} {position}, {fill} 50%,
              transparent 50%) center center / 98% 88% no-repeat; \\
              border-radius: 4px;
-             flex: 100 0 auto; width: 100px;\">{display_rounded}</span>")
+             flex: 100 0 auto; width: 100px;\">{display_rounded}</span>"
+      )
     } else {
       fill <- "lightgreen"
-      html_code <- glue::glue("<span style=\"display: \\
+      html_code <- glue::glue(
+        "<span style=\"display: \\
       inline-block;background: linear-gradient(90deg,
              transparent 50%, {fill} 50%, {fill} {position}, \\
              transparent {position}) center center / 98% 88% no-repeat;
              border-radius: 4px; flex: 100 0 auto; \\
-                              width: 100px;\">{display_rounded}</span>")
+                              width: 100px;\">{display_rounded}</span>"
+      )
     }
 
     html_code |>
@@ -70,14 +78,13 @@ bar_style_nb <- function(width, display) {
 #' @param color the required color
 #'
 #' @keywords internal
-add_color_to_confusion_metric <- function(performance_dat,
-                                          metric,
-                                          color) {
+add_color_to_confusion_metric <- function(performance_dat, metric, color) {
   performance_dat |>
     dplyr::mutate(
       metric_plot = 100 * {{ metric }} / .data$n_obs,
       metric_plot = purrr::map2(
-        metric_plot, {{ metric }},
+        metric_plot,
+        {{ metric }},
         .f = ~ bar_chart(
           value = .x,
           display = .y,
@@ -98,14 +105,13 @@ add_color_to_confusion_metric <- function(performance_dat,
 #' @param color the required color
 #'
 #' @keywords internal
-add_color_to_performance_metric <- function(performance_dat,
-                                            metric,
-                                            color) {
+add_color_to_performance_metric <- function(performance_dat, metric, color) {
   performance_dat |>
     dplyr::mutate(
       metric_plot = 100 * {{ metric }},
       metric_plot = purrr::map2(
-        metric_plot, {{ metric }},
+        metric_plot,
+        {{ metric }},
         .f = ~ bar_chart(
           value = .x,
           display = .y,
@@ -125,14 +131,13 @@ add_color_to_performance_metric <- function(performance_dat,
 #' @param color the required color
 #'
 #' @keywords internal
-add_color_to_lift <- function(performance_dat,
-                              metric,
-                              color) {
+add_color_to_lift <- function(performance_dat, metric, color) {
   performance_dat |>
     dplyr::mutate(
       metric_plot = 100 * {{ metric }} / max({{ metric }}, na.rm = TRUE),
       metric_plot = purrr::map2(
-        metric_plot, {{ metric }},
+        metric_plot,
+        {{ metric }},
         .f = ~ bar_chart(
           value = .x,
           display = .y,
@@ -148,11 +153,13 @@ add_color_to_lift <- function(performance_dat,
 add_color_to_predicted_positives <- function(performance_dat) {
   performance_dat |>
     mutate(
-      display_predicted_postivies =
-        glue::glue("{predicted_positives} ({round(ppcr  * 100, digits = 1)}%)"),
+      display_predicted_postivies = glue::glue(
+        "{predicted_positives} ({round(ppcr  * 100, digits = 1)}%)"
+      ),
       plot_predicted_positives = 100 * .data$ppcr,
       plot_predicted_positives = purrr::map2(
-        plot_predicted_positives, display_predicted_postivies,
+        plot_predicted_positives,
+        display_predicted_postivies,
         .f = ~ bar_chart(
           value = .x,
           display = .y,
@@ -173,14 +180,14 @@ add_color_to_net_benifit <- function(performance_data) {
     dplyr::mutate(
       NB_plot = .data$NB,
       NB_plot = purrr::map2(
-        NB_plot, NB,
+        NB_plot,
+        NB,
         .f = ~ bar_style_nb(width = .x, display = .y)
       )
     ) |>
     dplyr::mutate(NB = .data$NB_plot) |>
     dplyr::select(-.data$NB_plot)
 }
-
 
 
 #' Replancing NaN with NA
@@ -193,7 +200,6 @@ replace_nan_with_na <- function(performance_dat) {
   performance_dat$NPV[is.nan(performance_dat$NPV)] <- NA
   performance_dat$lift[is.nan(performance_dat$lift)] <- NA
   performance_dat$NB[is.nan(performance_dat$NB)] <- NA
-
 
   performance_dat
 }

--- a/R/performance_table_gt_functions.R
+++ b/R/performance_table_gt_functions.R
@@ -18,14 +18,14 @@ bar_chart <- function(value,
     if (no_round) {
       display_rounded <- display
     } else {
-      display_rounded <- round(display, digits = digits) %>%
+      display_rounded <- round(display, digits = digits) |>
         format(nsmall = digits)
     }
 
     glue::glue("<span style=\"display: inline-block;direction: ltr;
              background-color: {color}; color: black;
-             width: {value}%\">{display_rounded}</span>") %>%
-      as.character() %>%
+             width: {value}%\">{display_rounded}</span>") |>
+      as.character() |>
       gt::html()
   }
 }
@@ -36,7 +36,7 @@ bar_style_nb <- function(width, display) {
   } else {
     position <- paste0((0.5 + width / 2) * 100, "%")
 
-    display_rounded <- round(display, digits = 2) %>%
+    display_rounded <- round(display, digits = 2) |>
       format(nsmall = 2)
 
     if (width <= 0) {
@@ -57,8 +57,8 @@ bar_style_nb <- function(width, display) {
                               width: 100px;\">{display_rounded}</span>")
     }
 
-    html_code %>%
-      as.character() %>%
+    html_code |>
+      as.character() |>
       gt::html()
   }
 }
@@ -73,7 +73,7 @@ bar_style_nb <- function(width, display) {
 add_color_to_confusion_metric <- function(performance_dat,
                                           metric,
                                           color) {
-  performance_dat %>%
+  performance_dat |>
     dplyr::mutate(
       metric_plot = 100 * {{ metric }} / .data$n_obs,
       metric_plot = purrr::map2(
@@ -85,8 +85,8 @@ add_color_to_confusion_metric <- function(performance_dat,
           digits = 0
         )
       )
-    ) %>%
-    dplyr::mutate({{ metric }} := .data$metric_plot) %>%
+    ) |>
+    dplyr::mutate({{ metric }} := .data$metric_plot) |>
     dplyr::select(-.data$metric_plot)
 }
 
@@ -101,7 +101,7 @@ add_color_to_confusion_metric <- function(performance_dat,
 add_color_to_performance_metric <- function(performance_dat,
                                             metric,
                                             color) {
-  performance_dat %>%
+  performance_dat |>
     dplyr::mutate(
       metric_plot = 100 * {{ metric }},
       metric_plot = purrr::map2(
@@ -113,8 +113,8 @@ add_color_to_performance_metric <- function(performance_dat,
           digits = 2
         )
       )
-    ) %>%
-    dplyr::mutate({{ metric }} := metric_plot) %>%
+    ) |>
+    dplyr::mutate({{ metric }} := metric_plot) |>
     dplyr::select(-metric_plot)
 }
 
@@ -128,7 +128,7 @@ add_color_to_performance_metric <- function(performance_dat,
 add_color_to_lift <- function(performance_dat,
                               metric,
                               color) {
-  performance_dat %>%
+  performance_dat |>
     dplyr::mutate(
       metric_plot = 100 * {{ metric }} / max({{ metric }}, na.rm = TRUE),
       metric_plot = purrr::map2(
@@ -140,13 +140,13 @@ add_color_to_lift <- function(performance_dat,
           digits = 2
         )
       )
-    ) %>%
-    dplyr::mutate({{ metric }} := .data$metric_plot) %>%
+    ) |>
+    dplyr::mutate({{ metric }} := .data$metric_plot) |>
     dplyr::select(-metric_plot)
 }
 
 add_color_to_predicted_positives <- function(performance_dat) {
-  performance_dat %>%
+  performance_dat |>
     mutate(
       display_predicted_postivies =
         glue::glue("{predicted_positives} ({round(ppcr  * 100, digits = 1)}%)"),
@@ -169,15 +169,15 @@ add_color_to_predicted_positives <- function(performance_dat) {
 #' @keywords internal
 #' @inheritParams plot_roc_curve
 add_color_to_net_benifit <- function(performance_data) {
-  performance_data %>%
+  performance_data |>
     dplyr::mutate(
       NB_plot = .data$NB,
       NB_plot = purrr::map2(
         NB_plot, NB,
         .f = ~ bar_style_nb(width = .x, display = .y)
       )
-    ) %>%
-    dplyr::mutate(NB = .data$NB_plot) %>%
+    ) |>
+    dplyr::mutate(NB = .data$NB_plot) |>
     dplyr::select(-.data$NB_plot)
 }
 
@@ -209,20 +209,20 @@ add_colors_to_performance_dat <- function(performance_dat) {
 
   # print(n_obs_dat)
 
-  performance_dat %>%
-    dplyr::mutate(key = "key") %>%
-    dplyr::left_join(n_obs_dat %>% mutate(key = "key")) %>%
-    dplyr::select(-.data$key) %>%
-    add_color_to_confusion_metric(.data$TP, "lightgreen") %>%
-    add_color_to_confusion_metric(.data$TN, "lightgreen") %>%
-    add_color_to_confusion_metric(.data$FP, "pink") %>%
-    add_color_to_confusion_metric(.data$FN, "pink") %>%
-    select(-.data$n_obs) %>%
-    add_color_to_performance_metric(.data$sensitivity, "lightgreen") %>%
-    add_color_to_lift(.data$lift, "lightgreen") %>%
-    add_color_to_predicted_positives() %>%
-    add_color_to_performance_metric(.data$specificity, "lightgreen") %>%
-    add_color_to_performance_metric(.data$PPV, "lightgreen") %>%
-    add_color_to_performance_metric(.data$NPV, "lightgreen") %>%
+  performance_dat |>
+    dplyr::mutate(key = "key") |>
+    dplyr::left_join(n_obs_dat |> mutate(key = "key")) |>
+    dplyr::select(-.data$key) |>
+    add_color_to_confusion_metric(.data$TP, "lightgreen") |>
+    add_color_to_confusion_metric(.data$TN, "lightgreen") |>
+    add_color_to_confusion_metric(.data$FP, "pink") |>
+    add_color_to_confusion_metric(.data$FN, "pink") |>
+    select(-.data$n_obs) |>
+    add_color_to_performance_metric(.data$sensitivity, "lightgreen") |>
+    add_color_to_lift(.data$lift, "lightgreen") |>
+    add_color_to_predicted_positives() |>
+    add_color_to_performance_metric(.data$specificity, "lightgreen") |>
+    add_color_to_performance_metric(.data$PPV, "lightgreen") |>
+    add_color_to_performance_metric(.data$NPV, "lightgreen") |>
     add_color_to_net_benifit()
 }

--- a/R/plotly_helper_functions.R
+++ b/R/plotly_helper_functions.R
@@ -8,11 +8,11 @@ check_performance_data_type_for_plotly <- function(performance_data) {
     performance_data_type <- "one model"
   }
   if ((names(performance_data)[1] == "model") & (
-    length(unique(performance_data %>% pull(1))) == 1)) {
+    length(unique(performance_data |> pull(1))) == 1)) {
     performance_data_type <- "one model with model column"
   }
   if ((names(performance_data)[1] == "model") & (
-    length(unique(performance_data %>% pull(1))) > 1)) {
+    length(unique(performance_data |> pull(1))) > 1)) {
     performance_data_type <- "several models"
   }
   if (names(performance_data)[1] == "population") {
@@ -32,7 +32,7 @@ add_markers_and_lines_to_plotly <- function(plotly_object,
                                             performance_data_type) {
   if (performance_data_type %in%
     c("one model", "one model with model column")) {
-    plotly_with_markers_and_lines <- plotly_object %>%
+    plotly_with_markers_and_lines <- plotly_object |>
       plotly::add_trace(
         hoverinfo = "text",
         text = ~ paste(
@@ -54,7 +54,7 @@ add_markers_and_lines_to_plotly <- function(plotly_object,
   }
 
   if (performance_data_type == "several models") {
-    plotly_with_markers_and_lines <- plotly_object %>%
+    plotly_with_markers_and_lines <- plotly_object |>
       plotly::add_trace(
         hoverinfo = "text",
         text = ~ paste(
@@ -76,7 +76,7 @@ add_markers_and_lines_to_plotly <- function(plotly_object,
   }
 
   if (performance_data_type == "several populations") {
-    plotly_with_markers_and_lines <- plotly_object %>%
+    plotly_with_markers_and_lines <- plotly_object |>
       plotly::add_trace(
         hoverinfo = "text",
         text = ~ paste(
@@ -111,15 +111,15 @@ add_reference_lines_to_plotly <- function(plotly_object,
                                           reference_lines,
                                           performance_data_type = "one model") {
   if (performance_data_type == "several populations") {
-    reference_lines %>%
-      split(seq_len(nrow(.))) %>%
+    reference_lines |>
+      split(seq_len(nrow(reference_lines))) |>
       purrr::reduce(add_reference_lines_to_plotly,
         .init = plotly_object
-      ) %>%
-      add_markers() %>%
+      ) |>
+      add_markers() |>
       add_lines()
   } else {
-    plotly_object %>%
+    plotly_object |>
       plotly::add_lines(
         x = ~ c(reference_lines$x, reference_lines$xend),
         y = ~ c(reference_lines$y, reference_lines$yend),
@@ -147,14 +147,14 @@ set_styling_for_rtichoke <- function(plotly_object,
                                      max_y_range = NA,
                                      min_x_range = NA,
                                      max_x_range = NA) {
-  plotly_object %>%
-    remove_grid_lines_from_plotly() %>%
+  plotly_object |>
+    remove_grid_lines_from_plotly() |>
     set_axis_titles(curve,
       max_y_range = max_y_range,
       min_y_range = min_y_range,
       min_x_range = min_x_range,
       max_x_range = max_x_range
-    ) %>%
+    ) |>
     plotly::config(displayModeBar = FALSE)
 }
 
@@ -171,7 +171,7 @@ set_axis_titles <- function(plotly_object,
                             min_x_range = NA,
                             max_x_range = NA) {
   if (curve == "roc") {
-    plotly_obj <- plotly_object %>%
+    plotly_obj <- plotly_object |>
       plotly::layout(
         xaxis = list(
           title = "1 - Specificity",
@@ -186,7 +186,7 @@ set_axis_titles <- function(plotly_object,
   }
 
   if (curve == "lift") {
-    plotly_obj <- plotly_object %>%
+    plotly_obj <- plotly_object |>
       plotly::layout(
         xaxis = list(
           title = "Predicted Positives (Rate)",
@@ -203,7 +203,7 @@ set_axis_titles <- function(plotly_object,
   }
 
   if (curve == "precision recall") {
-    plotly_obj <- plotly_object %>%
+    plotly_obj <- plotly_object |>
       plotly::layout(
         xaxis = list(
           title = "Sensitivity",
@@ -220,7 +220,7 @@ set_axis_titles <- function(plotly_object,
   }
 
   if (curve == "gains") {
-    plotly_obj <- plotly_object %>%
+    plotly_obj <- plotly_object |>
       plotly::layout(
         xaxis = list(
           title = "Predicted Positives (Rate)",
@@ -237,7 +237,7 @@ set_axis_titles <- function(plotly_object,
   }
 
   if (curve == "decision") {
-    plotly_obj <- plotly_object %>%
+    plotly_obj <- plotly_object |>
       plotly::layout(
         xaxis = list(
           title = "Probability Threshold",
@@ -254,7 +254,7 @@ set_axis_titles <- function(plotly_object,
   }
 
   if (curve == "interventions avoided") {
-    plotly_obj <- plotly_object %>%
+    plotly_obj <- plotly_object |>
       plotly::layout(
         xaxis = list(
           title = "Probability Threshold",
@@ -295,7 +295,7 @@ add_interactive_marker_from_performance_data <- function(plotly_object,
     "one model",
     "one model with model column"
   )) {
-    plotly_plot <- plotly_object %>%
+    plotly_plot <- plotly_object |>
       plotly::add_markers(
         data = performance_data,
         x = x_perf_metric,
@@ -315,7 +315,7 @@ add_interactive_marker_from_performance_data <- function(plotly_object,
   }
 
   if (performance_data_type == "several models") {
-    plotly_plot <- plotly_object %>%
+    plotly_plot <- plotly_object |>
       plotly::add_markers(
         data = performance_data,
         x = x_perf_metric,
@@ -335,7 +335,7 @@ add_interactive_marker_from_performance_data <- function(plotly_object,
   }
 
   if (performance_data_type == "several populations") {
-    plotly_plot <- plotly_object %>%
+    plotly_plot <- plotly_object |>
       plotly::add_markers(
         data = performance_data,
         x = x_perf_metric,
@@ -393,11 +393,11 @@ add_lines_and_markers_from_performance_data <- function(plotly_object,
   } else {
     color_values_vec <- color_values[
       seq_len(
-        length(unique(performance_data %>%
+        length(unique(performance_data |>
           pull(1)))
       )
     ]
-    names(color_values_vec) <- unique(performance_data %>% pull(1))
+    names(color_values_vec) <- unique(performance_data |> pull(1))
   }
 
 
@@ -405,7 +405,7 @@ add_lines_and_markers_from_performance_data <- function(plotly_object,
     "one model",
     "one model with model column"
   )) {
-    plotly_base <- plotly_object %>%
+    plotly_base <- plotly_object |>
       plotly::add_trace(
         data = performance_data,
         x = x_perf_metric,
@@ -419,7 +419,7 @@ add_lines_and_markers_from_performance_data <- function(plotly_object,
   }
 
   if (performance_data_type == "several models") {
-    plotly_base <- plotly_object %>%
+    plotly_base <- plotly_object |>
       plotly::add_trace(
         data = performance_data,
         x = x_perf_metric,
@@ -434,7 +434,7 @@ add_lines_and_markers_from_performance_data <- function(plotly_object,
   }
 
   if (performance_data_type == "several populations") {
-    plotly_base <- plotly_object %>%
+    plotly_base <- plotly_object |>
       plotly::add_trace(
         data = performance_data,
         x = x_perf_metric,
@@ -484,13 +484,13 @@ create_reference_lines_for_plotly <- function(performance_table_type,
         plotly = TRUE,
         prevalence,
         performance_data = performance_data
-      ) %>%
+      ) |>
         plotly::plot_ly(
           x = ~x,
           y = ~y,
           height = size_height,
           width = size
-        ) %>%
+        ) |>
         plotly::add_lines(
           color = I("grey"),
           colors = population_color_vector,
@@ -503,12 +503,12 @@ create_reference_lines_for_plotly <- function(performance_table_type,
       reference_lines_for_plotly <- create_reference_lines_data_frame(curve,
         plotly = TRUE,
         prevalence
-      ) %>%
+      ) |>
         plotly::plot_ly(
           x = ~x, y = ~y,
           height = size_height,
           width = size
-        ) %>%
+        ) |>
         plotly::add_lines(
           color = I("grey"),
           colors = population_color_vector,
@@ -521,7 +521,7 @@ create_reference_lines_for_plotly <- function(performance_table_type,
         "precision recall",
         plotly = TRUE,
         prevalence
-      ) %>%
+      ) |>
         plotly::plot_ly(
           x = ~x,
           y = ~y,
@@ -529,7 +529,7 @@ create_reference_lines_for_plotly <- function(performance_table_type,
           colors = population_color_vector,
           height = size_height,
           width = size
-        ) %>%
+        ) |>
         plotly::add_lines(line = list(dash = "dash", width = 1.75))
     }
 
@@ -543,19 +543,19 @@ create_reference_lines_for_plotly <- function(performance_table_type,
 
       names(color_values) <- names(prevalence)
 
-      population_color_reference_vector <- color_values %>%
+      population_color_reference_vector <- color_values |>
         create_color_reference_lines_vector("gains")
 
 
-      population_linetype_reference_vector <- color_values %>%
+      population_linetype_reference_vector <- color_values |>
         create_linetype_reference_vector("gains")
 
 
       reference_lines_for_plotly <- create_reference_lines_data_frame("gains",
         plotly = TRUE,
         prevalence
-      ) %>%
-        # dplyr::left_join(color_values_dat) %>%
+      ) |>
+        # dplyr::left_join(color_values_dat) |>
         plotly::plot_ly(
           x = ~x,
           y = ~y,
@@ -563,7 +563,7 @@ create_reference_lines_for_plotly <- function(performance_table_type,
           colors = population_color_reference_vector,
           height = size_height,
           width = size
-        ) %>%
+        ) |>
         plotly::add_lines(
           line = list(width = 1.75),
           linetype = ~population,
@@ -581,10 +581,10 @@ create_reference_lines_for_plotly <- function(performance_table_type,
 
       names(color_values) <- names(prevalence)
 
-      population_color_reference_vector <- color_values %>%
+      population_color_reference_vector <- color_values |>
         create_color_reference_lines_vector("decision")
 
-      population_linetype_reference_vector <- color_values %>%
+      population_linetype_reference_vector <- color_values |>
         create_linetype_reference_vector("decision")
 
       reference_lines_for_plotly <- create_reference_lines_data_frame(
@@ -592,7 +592,7 @@ create_reference_lines_for_plotly <- function(performance_table_type,
         plotly = TRUE,
         prevalence,
         performance_data = performance_data
-      ) %>%
+      ) |>
         plotly::plot_ly(
           x = ~x,
           y = ~y,
@@ -602,7 +602,7 @@ create_reference_lines_for_plotly <- function(performance_table_type,
           width = size,
           hoverinfo = "text",
           text = ~text
-        ) %>%
+        ) |>
         plotly::add_lines(
           line = list(width = 1.75),
           linetype = ~population,

--- a/R/plotly_helper_functions.R
+++ b/R/plotly_helper_functions.R
@@ -7,12 +7,16 @@ check_performance_data_type_for_plotly <- function(performance_data) {
   if (!(names(performance_data)[1] %in% c("population", "model"))) {
     performance_data_type <- "one model"
   }
-  if ((names(performance_data)[1] == "model") & (
-    length(unique(performance_data |> pull(1))) == 1)) {
+  if (
+    (names(performance_data)[1] == "model") &
+      (length(unique(performance_data |> pull(1))) == 1)
+  ) {
     performance_data_type <- "one model with model column"
   }
-  if ((names(performance_data)[1] == "model") & (
-    length(unique(performance_data |> pull(1))) > 1)) {
+  if (
+    (names(performance_data)[1] == "model") &
+      (length(unique(performance_data |> pull(1))) > 1)
+  ) {
     performance_data_type <- "several models"
   }
   if (names(performance_data)[1] == "population") {
@@ -28,24 +32,47 @@ check_performance_data_type_for_plotly <- function(performance_data) {
 #' @param performance_data_type the type of the performance data
 #'
 #' @keywords internal
-add_markers_and_lines_to_plotly <- function(plotly_object,
-                                            performance_data_type) {
-  if (performance_data_type %in%
-    c("one model", "one model with model column")) {
+add_markers_and_lines_to_plotly <- function(
+  plotly_object,
+  performance_data_type
+) {
+  if (
+    performance_data_type %in%
+      c("one model", "one model with model column")
+  ) {
     plotly_with_markers_and_lines <- plotly_object |>
       plotly::add_trace(
         hoverinfo = "text",
         text = ~ paste(
-          "TPR (Sensitivity):", round(sensitivity, digits = 3), "<br>",
-          "FPR:", round(FPR, digits = 3), "<br>",
-          "Specificity", round(specificity, digits = 3), "<br>",
-          "Lift", round(lift, digits = 3), "<br>",
-          "PPV", round(PPV, digits = 3), "<br>",
-          "NPV", round(NPV, digits = 3), "<br>",
-          "TP:", TP, "<br>",
-          "TN:", TN, "<br>",
-          "FP:", FP, "<br>",
-          "FN:", FN
+          "TPR (Sensitivity):",
+          round(sensitivity, digits = 3),
+          "<br>",
+          "FPR:",
+          round(FPR, digits = 3),
+          "<br>",
+          "Specificity",
+          round(specificity, digits = 3),
+          "<br>",
+          "Lift",
+          round(lift, digits = 3),
+          "<br>",
+          "PPV",
+          round(PPV, digits = 3),
+          "<br>",
+          "NPV",
+          round(NPV, digits = 3),
+          "<br>",
+          "TP:",
+          TP,
+          "<br>",
+          "TN:",
+          TN,
+          "<br>",
+          "FP:",
+          FP,
+          "<br>",
+          "FN:",
+          FN
         ),
         type = "scatter",
         mode = "markers+lines",
@@ -58,17 +85,38 @@ add_markers_and_lines_to_plotly <- function(plotly_object,
       plotly::add_trace(
         hoverinfo = "text",
         text = ~ paste(
-          "Model:", model, "<br>",
-          "TPR (Sensitivity):", round(sensitivity, digits = 3), "<br>",
-          "FPR:", round(FPR, digits = 3), "<br>",
-          "Specificity", round(specificity, digits = 3), "<br>",
-          "LIFT", round(lift, digits = 3), "<br>",
-          "PPV", round(PPV, digits = 3), "<br>",
-          "NPV", round(NPV, digits = 3), "<br>",
-          "TP:", TP, "<br>",
-          "TN:", TN, "<br>",
-          "FP:", FP, "<br>",
-          "FN:", FN
+          "Model:",
+          model,
+          "<br>",
+          "TPR (Sensitivity):",
+          round(sensitivity, digits = 3),
+          "<br>",
+          "FPR:",
+          round(FPR, digits = 3),
+          "<br>",
+          "Specificity",
+          round(specificity, digits = 3),
+          "<br>",
+          "LIFT",
+          round(lift, digits = 3),
+          "<br>",
+          "PPV",
+          round(PPV, digits = 3),
+          "<br>",
+          "NPV",
+          round(NPV, digits = 3),
+          "<br>",
+          "TP:",
+          TP,
+          "<br>",
+          "TN:",
+          TN,
+          "<br>",
+          "FP:",
+          FP,
+          "<br>",
+          "FN:",
+          FN
         ),
         type = "scatter",
         mode = "markers+lines"
@@ -80,17 +128,38 @@ add_markers_and_lines_to_plotly <- function(plotly_object,
       plotly::add_trace(
         hoverinfo = "text",
         text = ~ paste(
-          "Population:", population, "<br>",
-          "TPR (Sensitivity):", round(sensitivity, digits = 3), "<br>",
-          "FPR:", round(FPR, digits = 3), "<br>",
-          "Specificity", round(specificity, digits = 3), "<br>",
-          "Lift", round(lift, digits = 3), "<br>",
-          "PPV", round(PPV, digits = 3), "<br>",
-          "NPV", round(NPV, digits = 3), "<br>",
-          "TP:", TP, "<br>",
-          "TN:", TN, "<br>",
-          "FP:", FP, "<br>",
-          "FN:", FN
+          "Population:",
+          population,
+          "<br>",
+          "TPR (Sensitivity):",
+          round(sensitivity, digits = 3),
+          "<br>",
+          "FPR:",
+          round(FPR, digits = 3),
+          "<br>",
+          "Specificity",
+          round(specificity, digits = 3),
+          "<br>",
+          "Lift",
+          round(lift, digits = 3),
+          "<br>",
+          "PPV",
+          round(PPV, digits = 3),
+          "<br>",
+          "NPV",
+          round(NPV, digits = 3),
+          "<br>",
+          "TP:",
+          TP,
+          "<br>",
+          "TN:",
+          TN,
+          "<br>",
+          "FP:",
+          FP,
+          "<br>",
+          "FN:",
+          FN
         ),
         type = "scatter",
         mode = "markers+lines"
@@ -100,22 +169,21 @@ add_markers_and_lines_to_plotly <- function(plotly_object,
 }
 
 
-
 #' Add Reference Lines to Plotly Object
 #'
 #' @param plotly_object a plotly plot for performance metrics
 #' @param performance_data_type the type of the Performance Data
 #' @param reference_lines dataframe of reference lines
 #' @keywords internal
-add_reference_lines_to_plotly <- function(plotly_object,
-                                          reference_lines,
-                                          performance_data_type = "one model") {
+add_reference_lines_to_plotly <- function(
+  plotly_object,
+  reference_lines,
+  performance_data_type = "one model"
+) {
   if (performance_data_type == "several populations") {
     reference_lines |>
       split(seq_len(nrow(reference_lines))) |>
-      purrr::reduce(add_reference_lines_to_plotly,
-        .init = plotly_object
-      ) |>
+      purrr::reduce(add_reference_lines_to_plotly, .init = plotly_object) |>
       add_markers() |>
       add_lines()
   } else {
@@ -130,8 +198,6 @@ add_reference_lines_to_plotly <- function(plotly_object,
 }
 
 
-
-
 #' Set styling for rtichoke plotly
 #'
 #' @param plotly_object a plotly object
@@ -141,15 +207,18 @@ add_reference_lines_to_plotly <- function(plotly_object,
 #' @param min_x_range the minimum value of x range (for decision curve)
 #' @param max_x_range the maximum value of x range (for decision curve)
 #' @keywords internal
-set_styling_for_rtichoke <- function(plotly_object,
-                                     curve,
-                                     min_y_range = NA,
-                                     max_y_range = NA,
-                                     min_x_range = NA,
-                                     max_x_range = NA) {
+set_styling_for_rtichoke <- function(
+  plotly_object,
+  curve,
+  min_y_range = NA,
+  max_y_range = NA,
+  min_x_range = NA,
+  max_x_range = NA
+) {
   plotly_object |>
     remove_grid_lines_from_plotly() |>
-    set_axis_titles(curve,
+    set_axis_titles(
+      curve,
       max_y_range = max_y_range,
       min_y_range = min_y_range,
       min_x_range = min_x_range,
@@ -159,17 +228,18 @@ set_styling_for_rtichoke <- function(plotly_object,
 }
 
 
-
 #' Set Titles for x and y axis in plotly objects
 #'
 #' @inheritParams set_styling_for_rtichoke
 #' @keywords internal
-set_axis_titles <- function(plotly_object,
-                            curve,
-                            max_y_range = NA,
-                            min_y_range = NA,
-                            min_x_range = NA,
-                            max_x_range = NA) {
+set_axis_titles <- function(
+  plotly_object,
+  curve,
+  max_y_range = NA,
+  min_y_range = NA,
+  min_x_range = NA,
+  max_x_range = NA
+) {
   if (curve == "roc") {
     plotly_obj <- plotly_object |>
       plotly::layout(
@@ -274,27 +344,29 @@ set_axis_titles <- function(plotly_object,
 }
 
 
-
-
-
 #' Add interactive marker based on performance data
 #'
 #' @inheritParams add_lines_and_markers_from_performance_data
 #' @inheritParams create_roc_curve
 #' @keywords internal
-add_interactive_marker_from_performance_data <- function(plotly_object,
-                                                         performance_data,
-                                                         performance_data_type,
-                                                         x_perf_metric,
-                                                         y_perf_metric,
-                                                         stratified_by = "probability_threshold") {
+add_interactive_marker_from_performance_data <- function(
+  plotly_object,
+  performance_data,
+  performance_data_type,
+  x_perf_metric,
+  y_perf_metric,
+  stratified_by = "probability_threshold"
+) {
   x_perf_metric <- enquo(x_perf_metric)
   y_perf_metric <- enquo(y_perf_metric)
 
-  if (performance_data_type %in% c(
-    "one model",
-    "one model with model column"
-  )) {
+  if (
+    performance_data_type %in%
+      c(
+        "one model",
+        "one model with model column"
+      )
+  ) {
     plotly_plot <- plotly_object |>
       plotly::add_markers(
         data = performance_data,
@@ -358,9 +430,6 @@ add_interactive_marker_from_performance_data <- function(plotly_object,
 }
 
 
-
-
-
 #' Add lines and markers based on performance data
 #'
 #' @param plotly_object a previous plotly object
@@ -370,41 +439,50 @@ add_interactive_marker_from_performance_data <- function(plotly_object,
 #' @param y_perf_metric performance metric for the y axis
 #' @param color_values color palette
 #' @keywords internal
-add_lines_and_markers_from_performance_data <- function(plotly_object,
-                                                        performance_data,
-                                                        performance_data_type,
-                                                        x_perf_metric,
-                                                        y_perf_metric,
-                                                        color_values = c(
-                                                          "#5BC0BE",
-                                                          "#FC8D62",
-                                                          "#8DA0CB",
-                                                          "#E78AC3",
-                                                          "#A4243B"
-                                                        )) {
+add_lines_and_markers_from_performance_data <- function(
+  plotly_object,
+  performance_data,
+  performance_data_type,
+  x_perf_metric,
+  y_perf_metric,
+  color_values = c(
+    "#5BC0BE",
+    "#FC8D62",
+    "#8DA0CB",
+    "#E78AC3",
+    "#A4243B"
+  )
+) {
   x_perf_metric <- enquo(x_perf_metric)
   y_perf_metric <- enquo(y_perf_metric)
 
-  if (performance_data_type %in% c(
-    "one model",
-    "one model with model column"
-  )) {
+  if (
+    performance_data_type %in%
+      c(
+        "one model",
+        "one model with model column"
+      )
+  ) {
     color_values_vec <- "black"
   } else {
     color_values_vec <- color_values[
       seq_len(
-        length(unique(performance_data |>
-          pull(1)))
+        length(unique(
+          performance_data |>
+            pull(1)
+        ))
       )
     ]
     names(color_values_vec) <- unique(performance_data |> pull(1))
   }
 
-
-  if (performance_data_type %in% c(
-    "one model",
-    "one model with model column"
-  )) {
+  if (
+    performance_data_type %in%
+      c(
+        "one model",
+        "one model with model column"
+      )
+  ) {
     plotly_base <- plotly_object |>
       plotly::add_trace(
         data = performance_data,
@@ -452,9 +530,6 @@ add_lines_and_markers_from_performance_data <- function(plotly_object,
 }
 
 
-
-
-
 #' Create reference lines plotly as the first stage of interactive plot
 #'
 #' @inheritParams create_roc_curve
@@ -465,22 +540,23 @@ add_lines_and_markers_from_performance_data <- function(plotly_object,
 #' @param population_color_vector color values
 #' @param size the size of the curve
 #' @keywords internal
-create_reference_lines_for_plotly <- function(performance_table_type,
-                                              curve,
-                                              prevalence = NA,
-                                              population_color_vector = NA,
-                                              size = NULL,
-                                              performance_data = NULL) {
-  size_height <- switch(is.null(size) + 1,
-    size + 50,
-    NULL
-  )
+create_reference_lines_for_plotly <- function(
+  performance_table_type,
+  curve,
+  prevalence = NA,
+  population_color_vector = NA,
+  size = NULL,
+  performance_data = NULL
+) {
+  size_height <- switch(is.null(size) + 1, size + 50, NULL)
 
-
-  if ((curve %in% c("roc", "lift")) || ((performance_table_type !=
-    "several populations"))) {
+  if (
+    (curve %in% c("roc", "lift")) ||
+      ((performance_table_type != "several populations"))
+  ) {
     if (curve %in% c("gains", "decision")) {
-      reference_lines_for_plotly <- create_reference_lines_data_frame(curve,
+      reference_lines_for_plotly <- create_reference_lines_data_frame(
+        curve,
         plotly = TRUE,
         prevalence,
         performance_data = performance_data
@@ -500,12 +576,14 @@ create_reference_lines_for_plotly <- function(performance_table_type,
           text = ~text
         )
     } else {
-      reference_lines_for_plotly <- create_reference_lines_data_frame(curve,
+      reference_lines_for_plotly <- create_reference_lines_data_frame(
+        curve,
         plotly = TRUE,
         prevalence
       ) |>
         plotly::plot_ly(
-          x = ~x, y = ~y,
+          x = ~x,
+          y = ~y,
           height = size_height,
           width = size
         ) |>
@@ -546,12 +624,11 @@ create_reference_lines_for_plotly <- function(performance_table_type,
       population_color_reference_vector <- color_values |>
         create_color_reference_lines_vector("gains")
 
-
       population_linetype_reference_vector <- color_values |>
         create_linetype_reference_vector("gains")
 
-
-      reference_lines_for_plotly <- create_reference_lines_data_frame("gains",
+      reference_lines_for_plotly <- create_reference_lines_data_frame(
+        "gains",
         plotly = TRUE,
         prevalence
       ) |>
@@ -615,18 +692,15 @@ create_reference_lines_for_plotly <- function(performance_table_type,
 }
 
 
-
-
-
-
-
 #' Creating color reference lines vector
 #'
 #' @param color_populations_vector color population vector
 #' @param curve a curve
 #' @keywords internal
-create_color_reference_lines_vector <- function(color_populations_vector,
-                                                curve) {
+create_color_reference_lines_vector <- function(
+  color_populations_vector,
+  curve
+) {
   if (curve == "gains") {
     color_populations_vector <- c(color_populations_vector, random = "grey")
   }
@@ -634,13 +708,10 @@ create_color_reference_lines_vector <- function(color_populations_vector,
     color_populations_vector <- color_populations_vector
   }
   if (curve == "decision") {
-    color_populations_vector <- c(color_populations_vector,
-      treat_none = "grey"
-    )
+    color_populations_vector <- c(color_populations_vector, treat_none = "grey")
   }
   color_populations_vector
 }
-
 
 
 #' Creating linetype reference lines vector

--- a/R/plots_for_performance_metrics.R
+++ b/R/plots_for_performance_metrics.R
@@ -8,19 +8,20 @@
 #' @param color_values color palette
 #'
 #' @keywords internal
-create_ggplot_for_performance_metrics <- function(performance_data,
-                                                  x_perf_metric,
-                                                  y_perf_metric,
-                                                  color_values = c(
-                                                    "#5BC0BE",
-                                                    "#FC8D62",
-                                                    "#8DA0CB",
-                                                    "#E78AC3",
-                                                    "#A4243B"
-                                                  )) {
+create_ggplot_for_performance_metrics <- function(
+  performance_data,
+  x_perf_metric,
+  y_perf_metric,
+  color_values = c(
+    "#5BC0BE",
+    "#FC8D62",
+    "#8DA0CB",
+    "#E78AC3",
+    "#A4243B"
+  )
+) {
   if (!(names(performance_data)[1] %in% c("population", "model"))) {
     color_values_vec <- "black"
-
 
     ggplot_for_performance_metrics <- ggplot2::ggplot() +
       ggplot2::geom_point(
@@ -28,19 +29,23 @@ create_ggplot_for_performance_metrics <- function(performance_data,
         ggplot2::aes_string(
           x = x_perf_metric,
           y = y_perf_metric
-        ), size = 1
+        ),
+        size = 1
       ) +
       ggplot2::geom_path(
         data = performance_data,
         ggplot2::aes_string(
           x = x_perf_metric,
           y = y_perf_metric
-        ), size = 1
+        ),
+        size = 1
       )
   } else {
     color_values_vec <- color_values[
-      seq_len(length(unique(performance_data |>
-        dplyr::pull(1))))
+      seq_len(length(unique(
+        performance_data |>
+          dplyr::pull(1)
+      )))
     ]
 
     if (length(unique(performance_data |> dplyr::pull(1))) == 1) {
@@ -59,7 +64,8 @@ create_ggplot_for_performance_metrics <- function(performance_data,
           y = y_perf_metric,
           group = names(performance_data)[1],
           color = names(performance_data)[1]
-        ), size = 1
+        ),
+        size = 1
       ) +
       ggplot2::geom_path(
         data = performance_data,
@@ -68,7 +74,8 @@ create_ggplot_for_performance_metrics <- function(performance_data,
           y = y_perf_metric,
           group = names(performance_data)[1],
           color = names(performance_data)[1]
-        ), size = 1
+        ),
+        size = 1
       )
   }
 

--- a/R/plots_for_performance_metrics.R
+++ b/R/plots_for_performance_metrics.R
@@ -39,16 +39,16 @@ create_ggplot_for_performance_metrics <- function(performance_data,
       )
   } else {
     color_values_vec <- color_values[
-      seq_len(length(unique(performance_data %>%
+      seq_len(length(unique(performance_data |>
         dplyr::pull(1))))
     ]
 
-    if (length(unique(performance_data %>% dplyr::pull(1))) == 1) {
+    if (length(unique(performance_data |> dplyr::pull(1))) == 1) {
       color_values_vec <- "black"
     }
 
-    if (length(unique(performance_data %>% dplyr::pull(1))) > 1) {
-      names(color_values_vec) <- unique(performance_data %>% dplyr::pull(1))
+    if (length(unique(performance_data |> dplyr::pull(1))) > 1) {
+      names(color_values_vec) <- unique(performance_data |> dplyr::pull(1))
     }
 
     ggplot_for_performance_metrics <- ggplot2::ggplot() +
@@ -84,7 +84,7 @@ create_ggplot_for_performance_metrics <- function(performance_data,
 #' @param plotly_object a plotly plot for performance metrics
 #' @keywords internal
 remove_grid_lines_from_plotly <- function(plotly_object) {
-  plotly_object %>%
+  plotly_object |>
     plotly::layout(
       xaxis = list(showgrid = FALSE),
       yaxis = list(showgrid = FALSE)

--- a/R/precision_recall.R
+++ b/R/precision_recall.R
@@ -74,25 +74,37 @@
 #'   stratified_by = "ppcr"
 #' )
 #' }
-create_precision_recall_curve <- function(probs,
-                                          reals,
-                                          by = 0.01,
-                                          stratified_by = "probability_threshold",
-                                          chosen_threshold = NA,
-                                          interactive = TRUE,
-                                          color_values = c(
-                                            "#1b9e77", "#d95f02",
-                                            "#7570b3", "#e7298a",
-                                            "#07004D", "#E6AB02",
-                                            "#FE5F55", "#54494B",
-                                            "#006E90", "#BC96E6",
-                                            "#52050A", "#1F271B",
-                                            "#BE7C4D", "#63768D",
-                                            "#08A045", "#320A28",
-                                            "#82FF9E", "#2176FF",
-                                            "#D1603D", "#585123"
-                                          ),
-                                          size = NULL) {
+create_precision_recall_curve <- function(
+  probs,
+  reals,
+  by = 0.01,
+  stratified_by = "probability_threshold",
+  chosen_threshold = NA,
+  interactive = TRUE,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  ),
+  size = NULL
+) {
   prepare_performance_data(
     probs = probs,
     reals = reals,
@@ -106,7 +118,6 @@ create_precision_recall_curve <- function(probs,
       size = size
     )
 }
-
 
 
 #' Precision Recall Curve from Performance Data
@@ -139,25 +150,40 @@ create_precision_recall_curve <- function(probs,
 #'
 #' @export
 
-plot_precision_recall_curve <- function(performance_data,
-                                        chosen_threshold = NA,
-                                        interactive = TRUE,
-                                        color_values = c(
-                                          "#1b9e77", "#d95f02",
-                                          "#7570b3", "#e7298a",
-                                          "#07004D", "#E6AB02",
-                                          "#FE5F55", "#54494B",
-                                          "#006E90", "#BC96E6",
-                                          "#52050A", "#1F271B",
-                                          "#BE7C4D", "#63768D",
-                                          "#08A045", "#320A28",
-                                          "#82FF9E", "#2176FF",
-                                          "#D1603D", "#585123"
-                                        ),
-                                        size = NULL) {
+plot_precision_recall_curve <- function(
+  performance_data,
+  chosen_threshold = NA,
+  interactive = TRUE,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  ),
+  size = NULL
+) {
   rtichoke_curve_list <- performance_data |>
-    create_rtichoke_curve_list("precision recall", size = size, color_values = color_values)
-
+    create_rtichoke_curve_list(
+      "precision recall",
+      size = size,
+      color_values = color_values
+    )
 
   perf_dat_type <- check_performance_data_type_for_plotly(performance_data)
   prevalence <- get_prevalence_from_performance_data(
@@ -169,7 +195,6 @@ plot_precision_recall_curve <- function(performance_data,
     performance_data
   )
 
-
   if (interactive == FALSE) {
     reference_lines <- create_reference_lines_data_frame(
       "precision recall",
@@ -178,7 +203,8 @@ plot_precision_recall_curve <- function(performance_data,
 
     precision_recall_curve <- performance_data |>
       create_ggplot_for_performance_metrics(
-        "sensitivity", "PPV",
+        "sensitivity",
+        "PPV",
         color_values
       ) |>
       add_reference_lines_to_ggplot(reference_lines) |>

--- a/R/precision_recall.R
+++ b/R/precision_recall.R
@@ -43,32 +43,32 @@
 #'
 #' create_precision_recall_curve(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   )
 #' )
 #'
 #' create_precision_recall_curve(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   ),
 #'   stratified_by = "ppcr"
@@ -98,7 +98,7 @@ create_precision_recall_curve <- function(probs,
     reals = reals,
     by = by,
     stratified_by = stratified_by
-  ) %>%
+  ) |>
     plot_precision_recall_curve(
       chosen_threshold = chosen_threshold,
       interactive = interactive,
@@ -118,22 +118,22 @@ create_precision_recall_curve <- function(probs,
 #' @examples
 #' \dontrun{
 #'
-#' one_pop_one_model %>%
+#' one_pop_one_model |>
 #'   plot_precision_recall_curve()
 #'
-#' one_pop_one_model_by_ppcr %>%
+#' one_pop_one_model_by_ppcr |>
 #'   plot_precision_recall_curve()
 #'
-#' multiple_models %>%
+#' multiple_models |>
 #'   plot_precision_recall_curve()
 #'
-#' multiple_models_by_ppcr %>%
+#' multiple_models_by_ppcr |>
 #'   plot_precision_recall_curve()
 #'
-#' multiple_populations %>%
+#' multiple_populations |>
 #'   plot_precision_recall_curve()
 #'
-#' multiple_populations_by_ppcr %>%
+#' multiple_populations_by_ppcr |>
 #'   plot_precision_recall_curve()
 #' }
 #'
@@ -176,12 +176,12 @@ plot_precision_recall_curve <- function(performance_data,
       prevalence
     )
 
-    precision_recall_curve <- performance_data %>%
+    precision_recall_curve <- performance_data |>
       create_ggplot_for_performance_metrics(
         "sensitivity", "PPV",
         color_values
-      ) %>%
-      add_reference_lines_to_ggplot(reference_lines) %>%
+      ) |>
+      add_reference_lines_to_ggplot(reference_lines) |>
       set_precision_recall_curve_limits() +
       ggplot2::xlab("Sensitivity") +
       ggplot2::ylab("PPV")

--- a/R/precision_recall.R
+++ b/R/precision_recall.R
@@ -191,10 +191,6 @@ plot_precision_recall_curve <- function(
     perf_dat_type
   )
 
-  stratified_by <- check_performance_data_stratification(
-    performance_data
-  )
-
   if (interactive == FALSE) {
     reference_lines <- create_reference_lines_data_frame(
       "precision recall",

--- a/R/prepare_performance_data.R
+++ b/R/prepare_performance_data.R
@@ -103,7 +103,7 @@ prepare_performance_data <- function(
   by = 0.01,
   stratified_by = "probability_threshold"
 ) {
-  . <- probability_threshold <- NULL
+  probability_threshold <- NULL
 
   check_probs_input(probs)
   check_real_input(reals)

--- a/R/prepare_performance_data.R
+++ b/R/prepare_performance_data.R
@@ -114,7 +114,7 @@ prepare_performance_data <- function(
     stop("Probabilities mustn't be greater than one ")
   }
 
-  if ((length(probs) > 1) & (length(reals) == 1)) {
+  if ((length(probs) > 1) && (length(reals) == 1)) {
     if (is.null(names(probs))) {
       names(probs) <- paste("model", seq_len(length(probs)))
     }
@@ -133,8 +133,8 @@ prepare_performance_data <- function(
     )
   }
 
-  if ((length(probs) > 1) & (length(reals) > 1)) {
-    if (is.null(names(probs)) & is.null(names(reals))) {
+  if ((length(probs) > 1) && (length(reals) > 1)) {
+    if (is.null(names(probs)) && is.null(names(reals))) {
       names(probs) <- paste("population", seq_len(length(probs)))
       names(reals) <- paste("population", seq_len(length(reals)))
     }
@@ -156,12 +156,12 @@ prepare_performance_data <- function(
 
   tibble::tibble(
     probability_threshold = if (
-      stratified_by != "probability_threshold" &
+      stratified_by != "probability_threshold" &&
         length(unique(probs[[1]])) != 1
     ) {
       stats::quantile(probs[[1]], probs = rev(seq(0, 1, by = by)))
     } else if (
-      stratified_by != "probability_threshold" &
+      stratified_by != "probability_threshold" &&
         length(unique(probs[[1]])) == 1
     ) {
       c(0, 1)
@@ -174,7 +174,7 @@ prepare_performance_data <- function(
   ) |>
     (\(data) {
       if (
-        stratified_by != "probability_threshold" &
+        stratified_by != "probability_threshold" &&
           length(unique(probs[[1]])) != 1
       ) {
         dplyr::mutate(
@@ -185,7 +185,7 @@ prepare_performance_data <- function(
           )
         )
       } else if (
-        stratified_by != "probability_threshold" &
+        stratified_by != "probability_threshold" &&
           length(unique(probs[[1]])) == 1
       ) {
         dplyr::mutate(data, ppcr = c(1, 0))

--- a/R/prepare_performance_data.R
+++ b/R/prepare_performance_data.R
@@ -65,32 +65,32 @@
 #'
 #' prepare_performance_data(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   )
 #' )
 #'
 #' prepare_performance_data(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   ),
 #'   stratified_by = "ppcr"
@@ -108,7 +108,7 @@ prepare_performance_data <- function(probs,
 
   match.arg(stratified_by, c("probability_threshold", "ppcr"))
 
-  if ((probs %>% purrr::map_lgl(~ any(.x > 1)) %>% any())) {
+  if ((probs |> purrr::map_lgl(~ any(.x > 1)) |> any())) {
     stop("Probabilities mustn't be greater than one ")
   }
 
@@ -118,7 +118,7 @@ prepare_performance_data <- function(probs,
     }
 
     return(
-      probs %>%
+      probs |>
         purrr::map(
           ~ prepare_performance_data(
             probs = list(.),
@@ -126,7 +126,7 @@ prepare_performance_data <- function(probs,
             by = by,
             stratified_by = stratified_by
           )
-        ) %>%
+        ) |>
         dplyr::bind_rows(.id = "model")
     )
   }
@@ -168,11 +168,11 @@ prepare_performance_data <- function(probs,
         digits = nchar(format(by, scientific = FALSE))
       )
     }
-  ) %>%
-    {
+  ) |>
+    (\(data) {
       if (stratified_by != "probability_threshold" &
           length(unique(probs[[1]])) != 1) {
-        dplyr::mutate(.,
+        dplyr::mutate(data,
           ppcr = round(seq(0, 1, by = by),
             digits = nchar(format(by, scientific = FALSE))
           )
@@ -180,14 +180,14 @@ prepare_performance_data <- function(probs,
       } else if (stratified_by != "probability_threshold" &
                  length(unique(probs[[1]])) == 1) {
         
-        dplyr::mutate(.,
+        dplyr::mutate(data,
                       ppcr = c(1, 0)
         )
         
       } else {
-        .
+        data
       }
-    } %>%
+    })() |>
     dplyr::mutate(
       TP = lapply(
         probability_threshold,
@@ -197,7 +197,7 @@ prepare_performance_data <- function(probs,
             sum(probs[[1]][reals[[1]] == 1] > x)
           )
         }
-      ) %>%
+      ) |>
         unlist(),
       TN = lapply(
         probability_threshold,
@@ -206,29 +206,29 @@ prepare_performance_data <- function(probs,
             sum(probs[[1]][reals[[1]] == 0] <= x)
           )
         }
-      ) %>%
+      ) |>
         unlist()
-    ) %>%
-    {
+    ) |>
+    (\(data) {
       if (stratified_by != "probability_threshold") {
-        dplyr::mutate(., TN = dplyr::case_when(
+        dplyr::mutate(data, TN = dplyr::case_when(
           ppcr != 1 ~ TN,
           TRUE ~ as.integer(0)
         ))
       } else {
-        .
+        data
       }
-    } %>%
-    {
+    })() |>
+    (\(data) {
       if (stratified_by != "probability_threshold") {
-        dplyr::mutate(., TP = dplyr::case_when(
+        dplyr::mutate(data, TP = dplyr::case_when(
           ppcr != 1 ~ TP,
           TRUE ~ as.integer(sum(reals[[1]]))
         ))
       } else {
-        .
+        data
       }
-    } %>%
+    })() |>
     dplyr::mutate(
       FN = sum(reals[[1]]) - TP,
       FP = N - sum(reals[[1]]) - TN,
@@ -239,16 +239,16 @@ prepare_performance_data <- function(probs,
       NPV = TN / (TN + FN),
       lift = (TP / (TP + FN)) / ((TP + FP) / N),
       predicted_positives = TP + FP
-    ) %>%
-    {
+    ) |>
+    (\(data) {
       if (stratified_by == "probability_threshold") {
-        dplyr::mutate(., NB = TP / N - (FP / N) * (
+        dplyr::mutate(data, NB = TP / N - (FP / N) * (
           probability_threshold / (1 - probability_threshold)))
       } else {
-        .
+        data
       }
-    } %>%
-    {
-      if (stratified_by == "probability_threshold") dplyr::mutate(., ppcr = (TP + FP) / N) else .
-    }
+    })() |>
+    (\(data) {
+      if (stratified_by == "probability_threshold") dplyr::mutate(data, ppcr = (TP + FP) / N) else data
+    })()
 }

--- a/R/prepare_performance_data.R
+++ b/R/prepare_performance_data.R
@@ -97,10 +97,12 @@
 #' )
 #'
 #' @export
-prepare_performance_data <- function(probs,
-                                     reals,
-                                     by = 0.01,
-                                     stratified_by = "probability_threshold") {
+prepare_performance_data <- function(
+  probs,
+  reals,
+  by = 0.01,
+  stratified_by = "probability_threshold"
+) {
   . <- probability_threshold <- NULL
 
   check_probs_input(probs)
@@ -136,7 +138,8 @@ prepare_performance_data <- function(probs,
       names(probs) <- paste("population", seq_len(length(probs)))
       names(reals) <- paste("population", seq_len(length(reals)))
     }
-    return(purrr::map2_dfr(probs,
+    return(purrr::map2_dfr(
+      probs,
       reals,
       ~ prepare_performance_data(
         list(.x),
@@ -152,16 +155,16 @@ prepare_performance_data <- function(probs,
   N <- length(probs[[1]])
 
   tibble::tibble(
-    probability_threshold = if (stratified_by != "probability_threshold" &
-                                length(unique(probs[[1]])) != 1) {
-      stats::quantile(probs[[1]],
-        probs = rev(seq(0, 1, by = by))
-      )
-    } else if (stratified_by != "probability_threshold" &
-               length(unique(probs[[1]])) == 1) {
-      
+    probability_threshold = if (
+      stratified_by != "probability_threshold" &
+        length(unique(probs[[1]])) != 1
+    ) {
+      stats::quantile(probs[[1]], probs = rev(seq(0, 1, by = by)))
+    } else if (
+      stratified_by != "probability_threshold" &
+        length(unique(probs[[1]])) == 1
+    ) {
       c(0, 1)
-      
     } else {
       round(
         seq(0, 1, by = by),
@@ -170,20 +173,22 @@ prepare_performance_data <- function(probs,
     }
   ) |>
     (\(data) {
-      if (stratified_by != "probability_threshold" &
-          length(unique(probs[[1]])) != 1) {
-        dplyr::mutate(data,
-          ppcr = round(seq(0, 1, by = by),
+      if (
+        stratified_by != "probability_threshold" &
+          length(unique(probs[[1]])) != 1
+      ) {
+        dplyr::mutate(
+          data,
+          ppcr = round(
+            seq(0, 1, by = by),
             digits = nchar(format(by, scientific = FALSE))
           )
         )
-      } else if (stratified_by != "probability_threshold" &
-                 length(unique(probs[[1]])) == 1) {
-        
-        dplyr::mutate(data,
-                      ppcr = c(1, 0)
-        )
-        
+      } else if (
+        stratified_by != "probability_threshold" &
+          length(unique(probs[[1]])) == 1
+      ) {
+        dplyr::mutate(data, ppcr = c(1, 0))
       } else {
         data
       }
@@ -192,7 +197,8 @@ prepare_performance_data <- function(probs,
       TP = lapply(
         probability_threshold,
         function(x) {
-          ifelse(x == 0,
+          ifelse(
+            x == 0,
             length(probs[[1]][reals[[1]] == 1]),
             sum(probs[[1]][reals[[1]] == 1] > x)
           )
@@ -202,29 +208,33 @@ prepare_performance_data <- function(probs,
       TN = lapply(
         probability_threshold,
         function(x) {
-          ifelse(x == 0, as.integer(0),
-            sum(probs[[1]][reals[[1]] == 0] <= x)
-          )
+          ifelse(x == 0, as.integer(0), sum(probs[[1]][reals[[1]] == 0] <= x))
         }
       ) |>
         unlist()
     ) |>
     (\(data) {
       if (stratified_by != "probability_threshold") {
-        dplyr::mutate(data, TN = dplyr::case_when(
-          ppcr != 1 ~ TN,
-          TRUE ~ as.integer(0)
-        ))
+        dplyr::mutate(
+          data,
+          TN = dplyr::case_when(
+            ppcr != 1 ~ TN,
+            TRUE ~ as.integer(0)
+          )
+        )
       } else {
         data
       }
     })() |>
     (\(data) {
       if (stratified_by != "probability_threshold") {
-        dplyr::mutate(data, TP = dplyr::case_when(
-          ppcr != 1 ~ TP,
-          TRUE ~ as.integer(sum(reals[[1]]))
-        ))
+        dplyr::mutate(
+          data,
+          TP = dplyr::case_when(
+            ppcr != 1 ~ TP,
+            TRUE ~ as.integer(sum(reals[[1]]))
+          )
+        )
       } else {
         data
       }
@@ -242,13 +252,21 @@ prepare_performance_data <- function(probs,
     ) |>
     (\(data) {
       if (stratified_by == "probability_threshold") {
-        dplyr::mutate(data, NB = TP / N - (FP / N) * (
-          probability_threshold / (1 - probability_threshold)))
+        dplyr::mutate(
+          data,
+          NB = TP /
+            N -
+            (FP / N) * (probability_threshold / (1 - probability_threshold))
+        )
       } else {
         data
       }
     })() |>
     (\(data) {
-      if (stratified_by == "probability_threshold") dplyr::mutate(data, ppcr = (TP + FP) / N) else data
+      if (stratified_by == "probability_threshold") {
+        dplyr::mutate(data, ppcr = (TP + FP) / N)
+      } else {
+        data
+      }
     })()
 }

--- a/R/prepare_performance_data.R
+++ b/R/prepare_performance_data.R
@@ -116,7 +116,7 @@ prepare_performance_data <- function(
 
   if ((length(probs) > 1) && (length(reals) == 1)) {
     if (is.null(names(probs))) {
-      names(probs) <- paste("model", seq_len(length(probs)))
+      names(probs) <- paste("model", seq_along(probs))
     }
 
     return(
@@ -135,8 +135,8 @@ prepare_performance_data <- function(
 
   if ((length(probs) > 1) && (length(reals) > 1)) {
     if (is.null(names(probs)) && is.null(names(reals))) {
-      names(probs) <- paste("population", seq_len(length(probs)))
-      names(reals) <- paste("population", seq_len(length(reals)))
+      names(probs) <- paste("population", seq_along(probs))
+      names(reals) <- paste("population", seq_along(reals))
     }
     return(purrr::map2_dfr(
       probs,

--- a/R/prevalence_table.R
+++ b/R/prevalence_table.R
@@ -51,7 +51,7 @@ create_table_for_prevalence <- function(
       tibble(real_positives = real_positives),
       n_obs
     ) |>
-      dplyr::mutate(population = forcats::fct_inorder(population))
+      dplyr::mutate(population = forcats::fct_inorder(.data$population))
 
     table_for_prevalence <- data_for_prevalence |>
       reactable::reactable(

--- a/R/prevalence_table.R
+++ b/R/prevalence_table.R
@@ -21,25 +21,27 @@ create_table_for_prevalence <- function(performance_data,
   )
 
   if (perf_dat_type == "several populations") {
+    prevalence <- performance_data |>
+      get_prevalence_from_performance_data()
+    real_positives <- performance_data |>
+      get_real_positives_from_performance_data()
+    n_obs <- performance_data |>
+      dplyr::rename(any_of(c(
+        "Model" = "model",
+        "Population" = "population",
+        "Threshold" = "threshold"
+      ))) |>
+      get_n_from_performance_data() |>
+      dplyr::select(n_obs)
+
     data_for_prevalence <- dplyr::bind_cols(
-      performance_data %>%
-        get_prevalence_from_performance_data() %>%
-        tibble(population = names(.), prevalence = .),
-      performance_data %>%
-        get_real_positives_from_performance_data() %>%
-        tibble(real_positives = .),
-      performance_data %>%
-        dplyr::rename(any_of(c(
-          "Model" = "model",
-          "Population" = "population",
-          "Threshold" = "threshold"
-        ))) %>%
-        get_n_from_performance_data() %>%
-        dplyr::select(n_obs)
-    ) %>%
+      tibble(population = names(prevalence), prevalence = prevalence),
+      tibble(real_positives = real_positives),
+      n_obs
+    ) |>
       dplyr::mutate(population = forcats::fct_inorder(population))
 
-    table_for_prevalence <- data_for_prevalence %>%
+    table_for_prevalence <- data_for_prevalence |>
       reactable::reactable(
         sortable = FALSE,
         columns = list(
@@ -117,7 +119,7 @@ create_table_for_prevalence <- function(performance_data,
       n_obs = as.numeric(get_n_from_performance_data(performance_data))
     )
 
-    table_for_prevalence <- data_for_prevalence %>%
+    table_for_prevalence <- data_for_prevalence |>
       reactable::reactable(
         sortable = FALSE,
         columns = list(

--- a/R/prevalence_table.R
+++ b/R/prevalence_table.R
@@ -3,19 +3,31 @@
 #' @inheritParams plot_roc_curve
 #'
 #' @keywords internal
-create_table_for_prevalence <- function(performance_data,
-                                        color_values = c(
-                                          "#1b9e77", "#d95f02",
-                                          "#7570b3", "#e7298a",
-                                          "#07004D", "#E6AB02",
-                                          "#FE5F55", "#54494B",
-                                          "#006E90", "#BC96E6",
-                                          "#52050A", "#1F271B",
-                                          "#BE7C4D", "#63768D",
-                                          "#08A045", "#320A28",
-                                          "#82FF9E", "#2176FF",
-                                          "#D1603D", "#585123"
-                                        )) {
+create_table_for_prevalence <- function(
+  performance_data,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  )
+) {
   perf_dat_type <- check_performance_data_type_for_plotly(
     performance_data = performance_data
   )
@@ -52,9 +64,7 @@ create_table_for_prevalence <- function(performance_data,
             cell = function(value) {
               width <- paste0(value * 100, "%")
               bar_chart_with_background(
-                format(round(value, digits = 2),
-                  nsmall = 2
-                ),
+                format(round(value, digits = 2), nsmall = 2),
                 width = width,
                 fill = "grey",
                 background = "#e1e1e1"
@@ -74,7 +84,8 @@ create_table_for_prevalence <- function(performance_data,
               }
               key_num <- as.character(key_num)
 
-              color <- switch(as.character(key_num),
+              color <- switch(
+                as.character(key_num),
                 "1" = color_values[1],
                 "2" = color_values[2],
                 "3" = color_values[3],
@@ -101,11 +112,13 @@ create_table_for_prevalence <- function(performance_data,
               tagList(badge, value)
             }
           )
-        ), fullWidth = FALSE,
+        ),
+        fullWidth = FALSE,
         details = function(index) {
           htmltools::div(
             "Real Positives = ",
-            as.numeric(data_for_prevalence$real_positives[index]), ", ",
+            as.numeric(data_for_prevalence$real_positives[index]),
+            ", ",
             " Total Population =  ",
             as.numeric(data_for_prevalence$n_obs[index])
           )
@@ -113,8 +126,9 @@ create_table_for_prevalence <- function(performance_data,
       )
   } else {
     data_for_prevalence <- tibble::tibble(
-      real_positives =
-        get_real_positives_from_performance_data(performance_data)[1],
+      real_positives = get_real_positives_from_performance_data(
+        performance_data
+      )[1],
       prevalence = get_prevalence_from_performance_data(performance_data)[1],
       n_obs = as.numeric(get_n_from_performance_data(performance_data))
     )
@@ -130,9 +144,7 @@ create_table_for_prevalence <- function(performance_data,
             cell = function(value) {
               width <- paste0(value * 100, "%")
               bar_chart_with_background(
-                format(round(value, digits = 2),
-                  nsmall = 2
-                ),
+                format(round(value, digits = 2), nsmall = 2),
                 width = width,
                 fill = "grey",
                 background = "#e1e1e1"
@@ -141,11 +153,13 @@ create_table_for_prevalence <- function(performance_data,
           ),
           n_obs = reactable::colDef(show = FALSE),
           real_positives = reactable::colDef(show = FALSE)
-        ), fullWidth = FALSE,
+        ),
+        fullWidth = FALSE,
         details = function(index) {
           htmltools::div(
             "Real Positives = ",
-            as.numeric(data_for_prevalence$real_positives[index]), ", ",
+            as.numeric(data_for_prevalence$real_positives[index]),
+            ", ",
             " Total Population =  ",
             as.numeric(data_for_prevalence$n_obs[index])
           )
@@ -157,14 +171,15 @@ create_table_for_prevalence <- function(performance_data,
 }
 
 
-
 status_badge <- function(color = "#aaa", width = "9px", height = width) {
-  span(style = list(
-    display = "inline-block",
-    marginRight = "8px",
-    width = width,
-    height = height,
-    backgroundColor = color,
-    borderRadius = "50%"
-  ))
+  span(
+    style = list(
+      display = "inline-block",
+      marginRight = "8px",
+      width = width,
+      height = height,
+      backgroundColor = color,
+      borderRadius = "50%"
+    )
+  )
 }

--- a/R/roc.R
+++ b/R/roc.R
@@ -115,7 +115,6 @@ create_roc_curve <- function(
   size = NULL
 ) {
   check_probs_input(probs)
-  # check_real_input(reals)
 
   if (!is.na(chosen_threshold)) {
     check_chosen_threshold_input(chosen_threshold)

--- a/R/roc.R
+++ b/R/roc.R
@@ -203,16 +203,6 @@ plot_roc_curve <- function(
     check_chosen_threshold_input(chosen_threshold)
   }
 
-  stratified_by <- check_performance_data_stratification(
-    performance_data
-  )
-
-  perf_dat_type <-
-    check_performance_data_type_for_plotly(performance_data = performance_data)
-
-  prevalence <-
-    get_prevalence_from_performance_data(performance_data, perf_dat_type)
-
   if (interactive == FALSE) {
     reference_lines <- create_reference_lines_data_frame("roc")
 

--- a/R/roc.R
+++ b/R/roc.R
@@ -232,5 +232,5 @@ plot_roc_curve <- function(
       create_plotly_curve()
   }
 
-  return(roc_curve)
+  roc_curve
 }

--- a/R/roc.R
+++ b/R/roc.R
@@ -52,32 +52,32 @@
 #'
 #' create_roc_curve(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   )
 #' )
 #'
 #' create_roc_curve(
 #'   probs = list(
-#'     "train" = example_dat %>%
-#'       dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |>
+#'       dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(estimated_probabilities),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(estimated_probabilities)
 #'   ),
 #'   reals = list(
-#'     "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+#'     "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
 #'       dplyr::pull(outcome),
-#'     "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+#'     "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
 #'       dplyr::pull(outcome)
 #'   ),
 #'   stratified_by = "ppcr"
@@ -113,7 +113,7 @@ create_roc_curve <- function(probs, reals, by = 0.01,
     reals = reals,
     by = by,
     stratified_by = stratified_by
-  ) %>%
+  ) |>
     plot_roc_curve(
       chosen_threshold = chosen_threshold,
       interactive = interactive,
@@ -134,22 +134,22 @@ create_roc_curve <- function(probs, reals, by = 0.01,
 #' @examples
 #' \dontrun{
 #'
-#' one_pop_one_model %>%
+#' one_pop_one_model |>
 #'   plot_roc_curve()
 #'
-#' one_pop_one_model_by_ppcr %>%
+#' one_pop_one_model_by_ppcr |>
 #'   plot_roc_curve()
 #'
-#' multiple_models %>%
+#' multiple_models |>
 #'   plot_roc_curve()
 #'
-#' multiple_models_by_ppcr %>%
+#' multiple_models_by_ppcr |>
 #'   plot_roc_curve()
 #'
-#' multiple_populations %>%
+#' multiple_populations |>
 #'   plot_roc_curve()
 #'
-#' multiple_populations_by_ppcr %>%
+#' multiple_populations_by_ppcr |>
 #'   plot_roc_curve()
 #' }
 #'
@@ -193,11 +193,11 @@ plot_roc_curve <- function(performance_data,
   if (interactive == FALSE) {
     reference_lines <- create_reference_lines_data_frame("roc")
 
-    roc_curve <- performance_data %>%
+    roc_curve <- performance_data |>
       create_ggplot_for_performance_metrics(
         "FPR",
         "sensitivity", color_values
-      ) %>%
+      ) |>
       add_reference_lines_to_ggplot(reference_lines) +
       ggplot2::xlab("1 - Specificity") +
       ggplot2::ylab("Sensitivity")

--- a/R/roc.R
+++ b/R/roc.R
@@ -1,6 +1,5 @@
 # ROC Curve ---------------------------------------------------------------
 
-
 #' ROC Curve
 #'
 #' Create a ROC Curve
@@ -83,24 +82,38 @@
 #'   stratified_by = "ppcr"
 #' )
 #' }
-create_roc_curve <- function(probs, reals, by = 0.01,
-                             stratified_by = "probability_threshold",
-                             chosen_threshold = NA,
-                             interactive = TRUE,
-                             color_values = c(
-                               "#1b9e77", "#d95f02",
-                               "#7570b3", "#e7298a",
-                               "#07004D", "#E6AB02",
-                               "#FE5F55", "#54494B",
-                               "#006E90", "#BC96E6",
-                               "#52050A", "#1F271B",
-                               "#BE7C4D", "#63768D",
-                               "#08A045", "#320A28",
-                               "#82FF9E", "#2176FF",
-                               "#D1603D", "#585123"
-                             ),
-                             title_included = FALSE,
-                             size = NULL) {
+create_roc_curve <- function(
+  probs,
+  reals,
+  by = 0.01,
+  stratified_by = "probability_threshold",
+  chosen_threshold = NA,
+  interactive = TRUE,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  ),
+  title_included = FALSE,
+  size = NULL
+) {
   check_probs_input(probs)
   # check_real_input(reals)
 
@@ -154,23 +167,35 @@ create_roc_curve <- function(probs, reals, by = 0.01,
 #' }
 #'
 #' @export
-plot_roc_curve <- function(performance_data,
-                           chosen_threshold = NA,
-                           interactive = TRUE,
-                           color_values = c(
-                             "#1b9e77", "#d95f02",
-                             "#7570b3", "#e7298a",
-                             "#07004D", "#E6AB02",
-                             "#FE5F55", "#54494B",
-                             "#006E90", "#BC96E6",
-                             "#52050A", "#1F271B",
-                             "#BE7C4D", "#63768D",
-                             "#08A045", "#320A28",
-                             "#82FF9E", "#2176FF",
-                             "#D1603D", "#585123"
-                           ),
-                           title_included = FALSE,
-                           size = NULL) {
+plot_roc_curve <- function(
+  performance_data,
+  chosen_threshold = NA,
+  interactive = TRUE,
+  color_values = c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  ),
+  title_included = FALSE,
+  size = NULL
+) {
   rtichoke_curve_list <- performance_data |>
     create_rtichoke_curve_list("roc", size = size, color_values = color_values)
 
@@ -178,11 +203,9 @@ plot_roc_curve <- function(performance_data,
     check_chosen_threshold_input(chosen_threshold)
   }
 
-
   stratified_by <- check_performance_data_stratification(
     performance_data
   )
-
 
   perf_dat_type <-
     check_performance_data_type_for_plotly(performance_data = performance_data)
@@ -196,7 +219,8 @@ plot_roc_curve <- function(performance_data,
     roc_curve <- performance_data |>
       create_ggplot_for_performance_metrics(
         "FPR",
-        "sensitivity", color_values
+        "sensitivity",
+        color_values
       ) |>
       add_reference_lines_to_ggplot(reference_lines) +
       ggplot2::xlab("1 - Specificity") +

--- a/README.Rmd
+++ b/README.Rmd
@@ -77,10 +77,10 @@ The user is required to provide a list with one vector for the predictions and a
 <!--   )  -->
 
 
-<!-- predictions_and_outcomes %>%  -->
-<!--   dplyr::sample_n(replace = FALSE, size = 6) %>%  -->
-<!--   gt::gt() %>%  -->
-<!--   gt::cols_align(align = "center") %>%  -->
+<!-- predictions_and_outcomes |>  -->
+<!--   dplyr::sample_n(replace = FALSE, size = 6) |>  -->
+<!--   gt::gt() |>  -->
+<!--   gt::cols_align(align = "center") |>  -->
 <!--   gt::fmt_number(columns = probs, -->
 <!--                  decimals  = 2)  -->
 <!-- ``` -->
@@ -116,10 +116,10 @@ The user is required to provide a list with one vector of predictions for each m
 <!--   real = as.numeric(rtichoke::example_dat$outcome))  -->
 
 
-<!-- predictions_and_outcomes %>%  -->
-<!--   dplyr::sample_n(replace = FALSE, size = 6) %>%  -->
-<!--   gt::gt() %>%  -->
-<!--   gt::cols_align(align = "center") %>%  -->
+<!-- predictions_and_outcomes |>  -->
+<!--   dplyr::sample_n(replace = FALSE, size = 6) |>  -->
+<!--   gt::gt() |>  -->
+<!--   gt::cols_align(align = "center") |>  -->
 <!--   gt::fmt_number(columns = 1:3, -->
 <!--                  decimals  = 2) -->
 <!-- ``` -->
@@ -153,39 +153,39 @@ The user is required to provide a list with one vector of predictions for each p
 <!-- set.seed(42) -->
 
 <!-- predictions_and_outcomes_train <- tibble::tibble( -->
-<!--     "probs" = example_dat %>% -->
-<!--       dplyr::filter(type_of_set == "train") %>% -->
+<!--     "probs" = example_dat |> -->
+<!--       dplyr::filter(type_of_set == "train") |> -->
 <!--       dplyr::pull(estimated_probabilities), -->
-<!--   real = example_dat %>% dplyr::filter(type_of_set == "train") %>% -->
-<!--       dplyr::pull(outcome) %>%  -->
+<!--   real = example_dat |> dplyr::filter(type_of_set == "train") |> -->
+<!--       dplyr::pull(outcome) |>  -->
 <!--     as.numeric())   -->
 
 <!-- predictions_and_outcomes_test <- tibble::tibble( -->
-<!--     "probs" = example_dat %>% -->
-<!--       dplyr::filter(type_of_set == "test") %>% -->
+<!--     "probs" = example_dat |> -->
+<!--       dplyr::filter(type_of_set == "test") |> -->
 <!--       dplyr::pull(estimated_probabilities), -->
-<!--   real = example_dat %>% dplyr::filter(type_of_set == "test") %>% -->
-<!--       dplyr::pull(outcome) %>%  -->
+<!--   real = example_dat |> dplyr::filter(type_of_set == "test") |> -->
+<!--       dplyr::pull(outcome) |>  -->
 <!--     as.numeric())   -->
 
 
 
-<!-- predictions_and_outcomes_train %>%  -->
-<!--   dplyr::sample_n(replace = FALSE, size = 6) %>%  -->
-<!--   gt::gt() %>% -->
+<!-- predictions_and_outcomes_train |>  -->
+<!--   dplyr::sample_n(replace = FALSE, size = 6) |>  -->
+<!--   gt::gt() |> -->
 <!--   gt::tab_header( -->
 <!--     title = gt::md("**Train Set**") -->
-<!--   )  %>%  -->
+<!--   )  |>  -->
 <!--   gt::fmt_number(columns = probs, -->
 <!--                  decimals  = 2) -->
 
 
-<!-- predictions_and_outcomes_test %>%  -->
-<!--   dplyr::sample_n(replace = FALSE, size = 6) %>%  -->
-<!--   gt::gt() %>% -->
+<!-- predictions_and_outcomes_test |>  -->
+<!--   dplyr::sample_n(replace = FALSE, size = 6) |>  -->
+<!--   gt::gt() |> -->
 <!--   gt::tab_header( -->
 <!--     title = gt::md("**Test Set**") -->
-<!--   )%>%  -->
+<!--   ) |>  -->
 <!--   gt::fmt_number(columns = probs, -->
 <!--                  decimals  = 2) -->
 
@@ -196,16 +196,16 @@ The user is required to provide a list with one vector of predictions for each p
 
 create_roc_curve(
   probs = list(
-    "Train" = example_dat %>%
-      dplyr::filter(type_of_set == "train") %>%
+    "Train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "Test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+    "Test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "Train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+    "Train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "Test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+    "Test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   )
 )
@@ -219,7 +219,7 @@ For some outputs in rtichoke you can alternatively prepare a performance data an
 instead of `create_*_curve` use `plot_*_curve` and instead of `create_performance_table` use `render_performance_table`:
 
 ```{r eval=FALSE, include = TRUE}
-one_pop_one_model_as_a_vector %>%
+one_pop_one_model_as_a_vector |>
   plot_roc_curve()
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,10 @@ predictions and a list with one vector for the outcomes.
 <!--   real = as.numeric( -->
 <!--     rtichoke::example_dat$outcome) -->
 <!--   )  -->
-<!-- predictions_and_outcomes %>%  -->
-<!--   dplyr::sample_n(replace = FALSE, size = 6) %>%  -->
-<!--   gt::gt() %>%  -->
-<!--   gt::cols_align(align = "center") %>%  -->
+<!-- predictions_and_outcomes |>  -->
+<!--   dplyr::sample_n(replace = FALSE, size = 6) |>  -->
+<!--   gt::gt() |>  -->
+<!--   gt::cols_align(align = "center") |>  -->
 <!--   gt::fmt_number(columns = probs, -->
 <!--                  decimals  = 2)  -->
 <!-- ``` -->
@@ -100,10 +100,10 @@ the population.
 <!--     "Bad Model" = example_dat$bad_model, -->
 <!--     "Random Guess" = example_dat$random_guess, -->
 <!--   real = as.numeric(rtichoke::example_dat$outcome))  -->
-<!-- predictions_and_outcomes %>%  -->
-<!--   dplyr::sample_n(replace = FALSE, size = 6) %>%  -->
-<!--   gt::gt() %>%  -->
-<!--   gt::cols_align(align = "center") %>%  -->
+<!-- predictions_and_outcomes |>  -->
+<!--   dplyr::sample_n(replace = FALSE, size = 6) |>  -->
+<!--   gt::gt() |>  -->
+<!--   gt::cols_align(align = "center") |>  -->
 <!--   gt::fmt_number(columns = 1:3, -->
 <!--                  decimals  = 2) -->
 <!-- ``` -->
@@ -133,33 +133,33 @@ for each population.
 <!-- library(rtichoke) -->
 <!-- set.seed(42) -->
 <!-- predictions_and_outcomes_train <- tibble::tibble( -->
-<!--     "probs" = example_dat %>% -->
-<!--       dplyr::filter(type_of_set == "train") %>% -->
+<!--     "probs" = example_dat |> -->
+<!--       dplyr::filter(type_of_set == "train") |> -->
 <!--       dplyr::pull(estimated_probabilities), -->
-<!--   real = example_dat %>% dplyr::filter(type_of_set == "train") %>% -->
-<!--       dplyr::pull(outcome) %>%  -->
+<!--   real = example_dat |> dplyr::filter(type_of_set == "train") |> -->
+<!--       dplyr::pull(outcome) |>  -->
 <!--     as.numeric())   -->
 <!-- predictions_and_outcomes_test <- tibble::tibble( -->
-<!--     "probs" = example_dat %>% -->
-<!--       dplyr::filter(type_of_set == "test") %>% -->
+<!--     "probs" = example_dat |> -->
+<!--       dplyr::filter(type_of_set == "test") |> -->
 <!--       dplyr::pull(estimated_probabilities), -->
-<!--   real = example_dat %>% dplyr::filter(type_of_set == "test") %>% -->
-<!--       dplyr::pull(outcome) %>%  -->
+<!--   real = example_dat |> dplyr::filter(type_of_set == "test") |> -->
+<!--       dplyr::pull(outcome) |>  -->
 <!--     as.numeric())   -->
-<!-- predictions_and_outcomes_train %>%  -->
-<!--   dplyr::sample_n(replace = FALSE, size = 6) %>%  -->
-<!--   gt::gt() %>% -->
+<!-- predictions_and_outcomes_train |>  -->
+<!--   dplyr::sample_n(replace = FALSE, size = 6) |>  -->
+<!--   gt::gt() |> -->
 <!--   gt::tab_header( -->
 <!--     title = gt::md("**Train Set**") -->
-<!--   )  %>%  -->
+<!--   )  |>  -->
 <!--   gt::fmt_number(columns = probs, -->
 <!--                  decimals  = 2) -->
-<!-- predictions_and_outcomes_test %>%  -->
-<!--   dplyr::sample_n(replace = FALSE, size = 6) %>%  -->
-<!--   gt::gt() %>% -->
+<!-- predictions_and_outcomes_test |>  -->
+<!--   dplyr::sample_n(replace = FALSE, size = 6) |>  -->
+<!--   gt::gt() |> -->
 <!--   gt::tab_header( -->
 <!--     title = gt::md("**Test Set**") -->
-<!--   )%>%  -->
+<!--   ) |>  -->
 <!--   gt::fmt_number(columns = probs, -->
 <!--                  decimals  = 2) -->
 <!-- ``` -->
@@ -167,16 +167,16 @@ for each population.
 ``` r
 create_roc_curve(
   probs = list(
-    "Train" = example_dat %>%
-      dplyr::filter(type_of_set == "train") %>%
+    "Train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "Test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+    "Test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "Train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+    "Train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "Test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+    "Test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   )
 )
@@ -190,7 +190,7 @@ data and use it as an input: instead of `create_*_curve` use
 `render_performance_table`:
 
 ``` r
-one_pop_one_model_as_a_vector %>%
+one_pop_one_model_as_a_vector |>
   plot_roc_curve()
 ```
 

--- a/data-raw/multiple_populations.R
+++ b/data-raw/multiple_populations.R
@@ -5,13 +5,16 @@ multiple_populations <- prepare_performance_data(
     "train" = example_dat |>
       dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
+    "test" = example_dat |>
+      dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
+    "test" = example_dat |>
+      dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   )
 )

--- a/data-raw/multiple_populations.R
+++ b/data-raw/multiple_populations.R
@@ -2,16 +2,16 @@
 
 multiple_populations <- prepare_performance_data(
   probs = list(
-    "train" = example_dat %>%
-      dplyr::filter(type_of_set == "train") %>%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   )
 )

--- a/data-raw/multiple_populations_by_ppcr.R
+++ b/data-raw/multiple_populations_by_ppcr.R
@@ -2,16 +2,16 @@
 
 multiple_populations_by_ppcr <- prepare_performance_data(
   probs = list(
-    "train" = example_dat %>%
-      dplyr::filter(type_of_set == "train") %>%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   ),
   stratified_by = "ppcr"

--- a/data-raw/multiple_populations_by_ppcr.R
+++ b/data-raw/multiple_populations_by_ppcr.R
@@ -5,13 +5,16 @@ multiple_populations_by_ppcr <- prepare_performance_data(
     "train" = example_dat |>
       dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
+    "test" = example_dat |>
+      dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
+    "test" = example_dat |>
+      dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   ),
   stratified_by = "ppcr"

--- a/inst/summary_report_template.Rmd
+++ b/inst/summary_report_template.Rmd
@@ -43,7 +43,7 @@ tibble::tribble(
   ~"type", ~"predicted_positive", ~"predicted_negative",
   "Real Positive", "TP", "FN",
   "Real Negative", "FP", "TN"
-) %>% 
+) |> 
   reactable::reactable(sortable = FALSE,
             fullWidth = FALSE,
             borderless = FALSE,

--- a/man/check_probs_input.Rd
+++ b/man/check_probs_input.Rd
@@ -18,24 +18,24 @@ Check probs input
 check_probs_input(example_dat$estimated_probabilities)
 
 list(
-  "train" = example_dat \%>\%
-    dplyr::filter(type_of_set == "train") \%>\%
+  "train" = example_dat |>
+    dplyr::filter(type_of_set == "train") |>
     dplyr::pull(estimated_probabilities),
-  "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+  "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
     dplyr::pull(estimated_probabilities)
-) \%>\%
+) |>
   check_probs_input()
 
 check_probs_input(c(example_dat$estimated_probabilities, -0.1))
 check_probs_input(c(example_dat$estimated_probabilities, 1.1))
 
 list(
-  "train" = example_dat \%>\%
-    dplyr::filter(type_of_set == "train") \%>\%
+  "train" = example_dat |>
+    dplyr::filter(type_of_set == "train") |>
     dplyr::pull(estimated_probabilities),
-  "test" = c(example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+  "test" = c(example_dat |> dplyr::filter(type_of_set == "test") |>
     dplyr::pull(estimated_probabilities), -0.2)
-) \%>\%
+) |>
   check_probs_input()
 }
 }

--- a/man/check_real_input.Rd
+++ b/man/check_real_input.Rd
@@ -14,25 +14,25 @@ Check real input
 check_real_input(example_dat$outcome)
 
 list(
-  "train" = example_dat \%>\%
-    dplyr::filter(type_of_set == "train") \%>\%
+  "train" = example_dat |>
+    dplyr::filter(type_of_set == "train") |>
     dplyr::pull(outcome),
-  "test" = example_dat \%>\%
-    dplyr::filter(type_of_set == "test") \%>\%
+  "test" = example_dat |>
+    dplyr::filter(type_of_set == "test") |>
     dplyr::pull(outcome)
-) \%>\%
+) |>
   check_real_input()
 
 check_real_input(c(example_dat$outcome, -0.1))
 check_real_input(c(example_dat$outcome, 1.1))
 
 list(
-  "train" = example_dat \%>\%
-    dplyr::filter(type_of_set == "train") \%>\%
+  "train" = example_dat |>
+    dplyr::filter(type_of_set == "train") |>
     dplyr::pull(outcome),
-  "test" = c(example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+  "test" = c(example_dat |> dplyr::filter(type_of_set == "test") |>
     dplyr::pull(outcome), -0.2)
-) \%>\%
+) |>
   check_real_input()
 }
 }

--- a/man/create_calibration_curve.Rd
+++ b/man/create_calibration_curve.Rd
@@ -73,16 +73,16 @@ create_calibration_curve(
 
 create_calibration_curve(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   ),
   type = "discrete"
@@ -91,16 +91,16 @@ create_calibration_curve(
 
 create_calibration_curve(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   ),
   type = "smooth"

--- a/man/create_calibration_curve_list.Rd
+++ b/man/create_calibration_curve_list.Rd
@@ -50,16 +50,16 @@ create_calibration_curve_list(
 
 create_calibration_curve_list(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   )
 )

--- a/man/create_conf_mat_list.Rd
+++ b/man/create_conf_mat_list.Rd
@@ -15,22 +15,22 @@ Create a list of confusion matrices
 \examples{
 \dontrun{
 
-one_pop_one_model \%>\%
+one_pop_one_model |>
   create_conf_mat_list()
 
-one_pop_one_model_by_ppcr \%>\%
+one_pop_one_model_by_ppcr |>
   create_conf_mat_list()
 
-multiple_models \%>\%
+multiple_models |>
   create_conf_mat_list()
 
-multiple_models_by_ppcr \%>\%
+multiple_models_by_ppcr |>
   create_conf_mat_list()
 
-multiple_populations \%>\%
+multiple_populations |>
   create_conf_mat_list()
 
-multiple_populations_by_ppcr \%>\%
+multiple_populations_by_ppcr |>
   create_conf_mat_list()
 }
 }

--- a/man/create_decision_curve.Rd
+++ b/man/create_decision_curve.Rd
@@ -104,32 +104,32 @@ create_decision_curve(
 
 create_decision_curve(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   )
 )
 
 create_decision_curve(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   ),
   type = "interventions avoided"
@@ -138,16 +138,16 @@ create_decision_curve(
 
 create_decision_curve(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   ),
   type = "combined"

--- a/man/create_gains_curve.Rd
+++ b/man/create_gains_curve.Rd
@@ -75,32 +75,32 @@ create_gains_curve(
 
 create_gains_curve(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   )
 )
 
 create_gains_curve(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   ),
   stratified_by = "ppcr"

--- a/man/create_lift_curve.Rd
+++ b/man/create_lift_curve.Rd
@@ -75,32 +75,32 @@ create_lift_curve(
 
 create_lift_curve(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   )
 )
 
 create_lift_curve(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   ),
   stratified_by = "ppcr"

--- a/man/create_performance_table.Rd
+++ b/man/create_performance_table.Rd
@@ -69,32 +69,32 @@ create_performance_table(
 
 create_performance_table(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   )
 )
 
 create_performance_table(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   ),
   stratified_by = "ppcr"

--- a/man/create_precision_recall_curve.Rd
+++ b/man/create_precision_recall_curve.Rd
@@ -75,32 +75,32 @@ create_precision_recall_curve(
 
 create_precision_recall_curve(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   )
 )
 
 create_precision_recall_curve(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   ),
   stratified_by = "ppcr"

--- a/man/create_roc_curve.Rd
+++ b/man/create_roc_curve.Rd
@@ -78,32 +78,32 @@ create_roc_curve(
 
 create_roc_curve(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   )
 )
 
 create_roc_curve(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   ),
   stratified_by = "ppcr"

--- a/man/create_summary_report.Rd
+++ b/man/create_summary_report.Rd
@@ -50,16 +50,16 @@ create_summary_report(
 
 create_summary_report(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   )
 )

--- a/man/create_table_for_auc.Rd
+++ b/man/create_table_for_auc.Rd
@@ -42,16 +42,19 @@ rtichoke:::create_table_for_auc(
 
 rtichoke:::create_table_for_auc(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |>
+      dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |>
+      dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   )
 )

--- a/man/define_limits_for_calibration_plot.Rd
+++ b/man/define_limits_for_calibration_plot.Rd
@@ -14,7 +14,7 @@ Define limits for Calibration Curve
 make_deciles_dat(
   probs = example_dat$estimated_probabilities,
   real = example_dat$outcome
-) \%>\%
+) |>
   define_limits_for_calibration_plot()
 }
 }

--- a/man/plot_decision_curve.Rd
+++ b/man/plot_decision_curve.Rd
@@ -46,31 +46,31 @@ Plot a Precision decision Curve
 \dontrun{
 
 
-one_pop_one_model \%>\%
+one_pop_one_model |>
   plot_decision_curve()
 
-one_pop_one_model \%>\%
+one_pop_one_model |>
   plot_decision_curve(type = "interventions avoided")
 
-one_pop_one_model \%>\%
+one_pop_one_model |>
   plot_decision_curve(type = "combined")
 
-multiple_models \%>\%
+multiple_models |>
   plot_decision_curve()
 
-multiple_models \%>\%
+multiple_models |>
   plot_decision_curve(type = "interventions avoided")
 
-multiple_models \%>\%
+multiple_models |>
   plot_decision_curve(type = "combined")
 
-multiple_populations \%>\%
+multiple_populations |>
   plot_decision_curve()
 
-multiple_populations \%>\%
+multiple_populations |>
   plot_decision_curve(type = "interventions avoided")
 
-multiple_populations \%>\%
+multiple_populations |>
   plot_decision_curve(type = "combined")
 }
 }

--- a/man/plot_gains_curve.Rd
+++ b/man/plot_gains_curve.Rd
@@ -32,22 +32,22 @@ Plot a Gains Curve
 \examples{
 \dontrun{
 
-one_pop_one_model \%>\%
+one_pop_one_model |>
   plot_gains_curve()
 
-one_pop_one_model_by_ppcr \%>\%
+one_pop_one_model_by_ppcr |>
   plot_gains_curve()
 
-multiple_models \%>\%
+multiple_models |>
   plot_gains_curve()
 
-multiple_models_by_ppcr \%>\%
+multiple_models_by_ppcr |>
   plot_gains_curve()
 
-multiple_populations \%>\%
+multiple_populations |>
   plot_gains_curve()
 
-multiple_populations_by_ppcr \%>\%
+multiple_populations_by_ppcr |>
   plot_gains_curve()
 }
 

--- a/man/plot_lift_curve.Rd
+++ b/man/plot_lift_curve.Rd
@@ -32,22 +32,22 @@ Plot a LIFT Curve
 \examples{
 \dontrun{
 
-one_pop_one_model \%>\%
+one_pop_one_model |>
   plot_lift_curve()
 
-one_pop_one_model_by_ppcr \%>\%
+one_pop_one_model_by_ppcr |>
   plot_lift_curve()
 
-multiple_models \%>\%
+multiple_models |>
   plot_lift_curve()
 
-multiple_models_by_ppcr \%>\%
+multiple_models_by_ppcr |>
   plot_lift_curve()
 
-multiple_populations \%>\%
+multiple_populations |>
   plot_lift_curve()
 
-multiple_populations_by_ppcr \%>\%
+multiple_populations_by_ppcr |>
   plot_lift_curve()
 }
 

--- a/man/plot_precision_recall_curve.Rd
+++ b/man/plot_precision_recall_curve.Rd
@@ -32,22 +32,22 @@ Plot a Precision Recall Curve
 \examples{
 \dontrun{
 
-one_pop_one_model \%>\%
+one_pop_one_model |>
   plot_precision_recall_curve()
 
-one_pop_one_model_by_ppcr \%>\%
+one_pop_one_model_by_ppcr |>
   plot_precision_recall_curve()
 
-multiple_models \%>\%
+multiple_models |>
   plot_precision_recall_curve()
 
-multiple_models_by_ppcr \%>\%
+multiple_models_by_ppcr |>
   plot_precision_recall_curve()
 
-multiple_populations \%>\%
+multiple_populations |>
   plot_precision_recall_curve()
 
-multiple_populations_by_ppcr \%>\%
+multiple_populations_by_ppcr |>
   plot_precision_recall_curve()
 }
 

--- a/man/plot_roc_curve.Rd
+++ b/man/plot_roc_curve.Rd
@@ -35,22 +35,22 @@ Plot a ROC Curve
 \examples{
 \dontrun{
 
-one_pop_one_model \%>\%
+one_pop_one_model |>
   plot_roc_curve()
 
-one_pop_one_model_by_ppcr \%>\%
+one_pop_one_model_by_ppcr |>
   plot_roc_curve()
 
-multiple_models \%>\%
+multiple_models |>
   plot_roc_curve()
 
-multiple_models_by_ppcr \%>\%
+multiple_models_by_ppcr |>
   plot_roc_curve()
 
-multiple_populations \%>\%
+multiple_populations |>
   plot_roc_curve()
 
-multiple_populations_by_ppcr \%>\%
+multiple_populations_by_ppcr |>
   plot_roc_curve()
 }
 

--- a/man/prepare_performance_data.Rd
+++ b/man/prepare_performance_data.Rd
@@ -81,32 +81,32 @@ prepare_performance_data(
 
 prepare_performance_data(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   )
 )
 
 prepare_performance_data(
   probs = list(
-    "train" = example_dat \%>\%
-      dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
       dplyr::pull(estimated_probabilities),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(estimated_probabilities)
   ),
   reals = list(
-    "train" = example_dat \%>\% dplyr::filter(type_of_set == "train") \%>\%
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
       dplyr::pull(outcome),
-    "test" = example_dat \%>\% dplyr::filter(type_of_set == "test") \%>\%
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
       dplyr::pull(outcome)
   ),
   stratified_by = "ppcr"

--- a/man/render_performance_table.Rd
+++ b/man/render_performance_table.Rd
@@ -28,22 +28,22 @@ Create a Performance Table
 \examples{
 \dontrun{
 
-one_pop_one_model \%>\%
+one_pop_one_model |>
   render_performance_table()
 
-one_pop_one_model_by_ppcr \%>\%
+one_pop_one_model_by_ppcr |>
   render_performance_table()
 
-multiple_models \%>\%
+multiple_models |>
   render_performance_table()
 
-multiple_models_by_ppcr \%>\%
+multiple_models_by_ppcr |>
   render_performance_table()
 
-multiple_populations \%>\%
+multiple_populations |>
   render_performance_table()
 
-multiple_populations_by_ppcr \%>\%
+multiple_populations_by_ppcr |>
   render_performance_table()
 }
 

--- a/tests/testthat/test-calibration.R
+++ b/tests/testthat/test-calibration.R
@@ -14,7 +14,7 @@ test_that("limits of calibration curve", {
   limits_calibration_curve <- rtichoke:::make_deciles_dat(
     probs = example_dat$estimated_probabilities,
     real = example_dat$outcome
-  ) %>%
+  ) |>
     rtichoke:::define_limits_for_calibration_plot()
 
   expect_equal(length(limits_calibration_curve), 2)
@@ -41,20 +41,20 @@ test_that("calibration validates probability and outcome inputs", {
   expect_error(
     create_calibration_curve_list(
       probs = list(
-        train = example_dat %>%
-          dplyr::filter(type_of_set == "train") %>%
+        train = example_dat |>
+          dplyr::filter(type_of_set == "train") |>
           dplyr::pull(estimated_probabilities),
-        test = example_dat %>%
-          dplyr::filter(type_of_set == "test") %>%
+        test = example_dat |>
+          dplyr::filter(type_of_set == "test") |>
           dplyr::pull(estimated_probabilities)
       ),
       reals = list(
-        train = example_dat %>%
-          dplyr::filter(type_of_set == "train") %>%
+        train = example_dat |>
+          dplyr::filter(type_of_set == "train") |>
           dplyr::pull(outcome),
-        test = example_dat %>%
-          dplyr::filter(type_of_set == "test") %>%
-          dplyr::pull(outcome) %>%
+        test = example_dat |>
+          dplyr::filter(type_of_set == "test") |>
+          dplyr::pull(outcome) |>
           replace(1, 2)
       )
     ),

--- a/tests/testthat/test-calibration.R
+++ b/tests/testthat/test-calibration.R
@@ -5,8 +5,10 @@ test_that("test deciles dat", {
   )
 
   expect_identical(deciles_dat$quintile, 1:10)
-  expect_identical(names(deciles_dat),
-                   c("quintile", "y", "x", "sum_reals", "total_obs"))
+  expect_identical(
+    names(deciles_dat),
+    c("quintile", "y", "x", "sum_reals", "total_obs")
+  )
 })
 
 

--- a/tests/testthat/test-check_inputs.R
+++ b/tests/testthat/test-check_inputs.R
@@ -10,16 +10,16 @@ test_that("probs must be in range of [0,1]", {
 
   expect_error(
     list(
-      "train" = example_dat %>%
-        dplyr::filter(type_of_set == "train") %>%
+      "train" = example_dat |>
+        dplyr::filter(type_of_set == "train") |>
         dplyr::pull(estimated_probabilities),
       "test" = c(
-        example_dat %>%
-          dplyr::filter(type_of_set == "test") %>%
+        example_dat |>
+          dplyr::filter(type_of_set == "test") |>
           dplyr::pull(estimated_probabilities),
         -0.2
       )
-    ) %>%
+    ) |>
       check_probs_input(),
     "Estimated Probabilities are out of the range"
   )
@@ -38,16 +38,16 @@ test_that("real must be 0 or 1", {
 
   expect_error(
     list(
-      "train" = example_dat %>%
-        dplyr::filter(type_of_set == "train") %>%
+      "train" = example_dat |>
+        dplyr::filter(type_of_set == "train") |>
         dplyr::pull(outcome),
       "test" = c(
-        example_dat %>%
-          dplyr::filter(type_of_set == "test") %>%
+        example_dat |>
+          dplyr::filter(type_of_set == "test") |>
           dplyr::pull(outcome),
         0.2
       )
-    ) %>%
+    ) |>
       rtichoke:::check_real_input(),
     "Outcomes are out of the range"
   )
@@ -94,7 +94,7 @@ test_that("public curve builders reject out-of-range probabilities", {
 
 test_that("plot functions reject incompatible stratification options", {
   expect_error(
-    train_and_test_sets %>%
+    train_and_test_sets |>
       plot_roc_curve(
         interactive = FALSE,
         stratified_by = "ppcr"
@@ -102,7 +102,7 @@ test_that("plot functions reject incompatible stratification options", {
   )
 
   expect_error(
-    train_and_test_sets %>%
+    train_and_test_sets |>
       plot_lift_curve(
         interactive = FALSE,
         stratified_by = "ppcr"
@@ -110,7 +110,7 @@ test_that("plot functions reject incompatible stratification options", {
   )
 
   expect_error(
-    train_and_test_sets %>%
+    train_and_test_sets |>
       plot_precision_recall_curve(
         interactive = FALSE,
         main_slider = "ppcr"
@@ -118,7 +118,7 @@ test_that("plot functions reject incompatible stratification options", {
   )
 
   expect_error(
-    train_and_test_sets %>%
+    train_and_test_sets |>
       plot_gains_curve(
         interactive = FALSE,
         main_slider = "ppcr"
@@ -126,12 +126,12 @@ test_that("plot functions reject incompatible stratification options", {
   )
 
   expect_error(
-    train_and_test_sets_enforced_percentiles_symmetry %>%
+    train_and_test_sets_enforced_percentiles_symmetry |>
       plot_gains_curve(stratified_by = "ppcr")
   )
 
   expect_error(
-    train_and_test_sets %>%
+    train_and_test_sets |>
       plot_decision_curve(
         interactive = FALSE,
         main_slider = "ppcr"
@@ -139,7 +139,7 @@ test_that("plot functions reject incompatible stratification options", {
   )
 
   expect_error(
-    train_and_test_sets_enforced_percentiles_symmetry %>%
+    train_and_test_sets_enforced_percentiles_symmetry |>
       plot_decision_curve(interactive = FALSE)
   )
 })

--- a/tests/testthat/test-performance-tables.R
+++ b/tests/testthat/test-performance-tables.R
@@ -8,8 +8,20 @@ test_that("Performance Table names are correct", {
       reals = list(example_dat$outcome)
     )),
     c(
-      "model", "probability_threshold", "TP", "TN", "FN", "FP", "sensitivity",
-      "FPR", "specificity", "PPV", "NPV", "lift", "predicted_positives", "NB",
+      "model",
+      "probability_threshold",
+      "TP",
+      "TN",
+      "FN",
+      "FP",
+      "sensitivity",
+      "FPR",
+      "specificity",
+      "PPV",
+      "NPV",
+      "lift",
+      "predicted_positives",
+      "NB",
       "ppcr"
     )
   )
@@ -20,8 +32,19 @@ test_that("Performance Table names are correct", {
       reals = list(example_dat$outcome)
     )),
     c(
-      "probability_threshold", "TP", "TN", "FN", "FP", "sensitivity",
-      "FPR", "specificity", "PPV", "NPV", "lift", "predicted_positives", "NB",
+      "probability_threshold",
+      "TP",
+      "TN",
+      "FN",
+      "FP",
+      "sensitivity",
+      "FPR",
+      "specificity",
+      "PPV",
+      "NPV",
+      "lift",
+      "predicted_positives",
+      "NB",
       "ppcr"
     )
   )
@@ -32,19 +55,34 @@ test_that("Performance Table names are correct", {
         "train" = example_dat |>
           dplyr::filter(type_of_set == "train") |>
           dplyr::pull(estimated_probabilities),
-        "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
+        "test" = example_dat |>
+          dplyr::filter(type_of_set == "test") |>
           dplyr::pull(estimated_probabilities)
       ),
       reals = list(
-        "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
+        "train" = example_dat |>
+          dplyr::filter(type_of_set == "train") |>
           dplyr::pull(outcome),
-        "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
+        "test" = example_dat |>
+          dplyr::filter(type_of_set == "test") |>
           dplyr::pull(outcome)
       )
     )),
     c(
-      "population", "probability_threshold", "TP", "TN", "FN", "FP", "sensitivity",
-      "FPR", "specificity", "PPV", "NPV", "lift", "predicted_positives", "NB",
+      "population",
+      "probability_threshold",
+      "TP",
+      "TN",
+      "FN",
+      "FP",
+      "sensitivity",
+      "FPR",
+      "specificity",
+      "PPV",
+      "NPV",
+      "lift",
+      "predicted_positives",
+      "NB",
       "ppcr"
     )
   )

--- a/tests/testthat/test-performance-tables.R
+++ b/tests/testthat/test-performance-tables.R
@@ -29,16 +29,16 @@ test_that("Performance Table names are correct", {
   expect_equal(
     names(prepare_performance_data(
       probs = list(
-        "train" = example_dat %>%
-          dplyr::filter(type_of_set == "train") %>%
+        "train" = example_dat |>
+          dplyr::filter(type_of_set == "train") |>
           dplyr::pull(estimated_probabilities),
-        "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+        "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
           dplyr::pull(estimated_probabilities)
       ),
       reals = list(
-        "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+        "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
           dplyr::pull(outcome),
-        "test" = example_dat %>% dplyr::filter(type_of_set == "test") %>%
+        "test" = example_dat |> dplyr::filter(type_of_set == "test") |>
           dplyr::pull(outcome)
       )
     )),

--- a/tests/testthat/test-prepare_performance_data.R
+++ b/tests/testthat/test-prepare_performance_data.R
@@ -4,14 +4,6 @@ test_that("Estimated Probabilities are in Range", {
     reals = c(example_dat$outcome, 1)
   ))
 
-  # expect_error(prepare_performance_data(
-  #   probs = list(
-  #     "First Model" = c(example_dat$estimated_probabilities, 1.1),
-  #     "Second Model" = c(example_dat$random_guess, -0.2)
-  #   ),
-  #   reals = c(example_dat$outcome, 1)
-  # ))
-
   expect_error(
     prepare_performance_data(
       probs = list(
@@ -42,11 +34,6 @@ test_that("Estimated Probabilities are in Range", {
 
 
 test_that("Outcomes are 1 or 0", {
-  # expect_error(prepare_performance_data(
-  #   probs = c(example_dat$estimated_probabilities, 0.2),
-  #   reals = c(example_dat$outcome, 1.2)
-  # ))
-
   expect_error(prepare_performance_data(
     probs = list(
       "First Model" = c(example_dat$estimated_probabilities, 1.1),
@@ -54,22 +41,4 @@ test_that("Outcomes are 1 or 0", {
     ),
     reals = c(example_dat$outcome, 2)
   ))
-
-  # expect_error(
-  #   prepare_performance_data(
-  #     probs = list(
-  #       "train" = example_dat |>
-  #         dplyr::filter(type_of_set == "train") |>
-  #         dplyr::pull(estimated_probabilities),
-  #       "test" = c(example_dat |> dplyr::filter(type_of_set == "test") |>
-  #         dplyr::pull(estimated_probabilities), 0.2)
-  #     ),
-  #     reals = list(
-  #       "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
-  #         dplyr::pull(outcome),
-  #       "test" = c(example_dat |> dplyr::filter(type_of_set == "test") |>
-  #         dplyr::pull(outcome), 2)
-  #     )
-  #   )
-  # )
 })

--- a/tests/testthat/test-prepare_performance_data.R
+++ b/tests/testthat/test-prepare_performance_data.R
@@ -15,16 +15,16 @@ test_that("Estimated Probabilities are in Range", {
   expect_error(
     prepare_performance_data(
       probs = list(
-        "train" = example_dat %>%
-          dplyr::filter(type_of_set == "train") %>%
+        "train" = example_dat |>
+          dplyr::filter(type_of_set == "train") |>
           dplyr::pull(estimated_probabilities),
-        "test" = c(example_dat %>% dplyr::filter(type_of_set == "test") %>%
+        "test" = c(example_dat |> dplyr::filter(type_of_set == "test") |>
           dplyr::pull(estimated_probabilities), -0.2)
       ),
       reals = list(
-        "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+        "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
           dplyr::pull(outcome),
-        "test" = c(example_dat %>% dplyr::filter(type_of_set == "test") %>%
+        "test" = c(example_dat |> dplyr::filter(type_of_set == "test") |>
           dplyr::pull(outcome), 1)
       )
     )
@@ -49,16 +49,16 @@ test_that("Outcomes are 1 or 0", {
   # expect_error(
   #   prepare_performance_data(
   #     probs = list(
-  #       "train" = example_dat %>%
-  #         dplyr::filter(type_of_set == "train") %>%
+  #       "train" = example_dat |>
+  #         dplyr::filter(type_of_set == "train") |>
   #         dplyr::pull(estimated_probabilities),
-  #       "test" = c(example_dat %>% dplyr::filter(type_of_set == "test") %>%
+  #       "test" = c(example_dat |> dplyr::filter(type_of_set == "test") |>
   #         dplyr::pull(estimated_probabilities), 0.2)
   #     ),
   #     reals = list(
-  #       "train" = example_dat %>% dplyr::filter(type_of_set == "train") %>%
+  #       "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
   #         dplyr::pull(outcome),
-  #       "test" = c(example_dat %>% dplyr::filter(type_of_set == "test") %>%
+  #       "test" = c(example_dat |> dplyr::filter(type_of_set == "test") |>
   #         dplyr::pull(outcome), 2)
   #     )
   #   )

--- a/tests/testthat/test-prepare_performance_data.R
+++ b/tests/testthat/test-prepare_performance_data.R
@@ -18,14 +18,23 @@ test_that("Estimated Probabilities are in Range", {
         "train" = example_dat |>
           dplyr::filter(type_of_set == "train") |>
           dplyr::pull(estimated_probabilities),
-        "test" = c(example_dat |> dplyr::filter(type_of_set == "test") |>
-          dplyr::pull(estimated_probabilities), -0.2)
+        "test" = c(
+          example_dat |>
+            dplyr::filter(type_of_set == "test") |>
+            dplyr::pull(estimated_probabilities),
+          -0.2
+        )
       ),
       reals = list(
-        "train" = example_dat |> dplyr::filter(type_of_set == "train") |>
+        "train" = example_dat |>
+          dplyr::filter(type_of_set == "train") |>
           dplyr::pull(outcome),
-        "test" = c(example_dat |> dplyr::filter(type_of_set == "test") |>
-          dplyr::pull(outcome), 1)
+        "test" = c(
+          example_dat |>
+            dplyr::filter(type_of_set == "test") |>
+            dplyr::pull(outcome),
+          1
+        )
       )
     )
   )

--- a/vignettes/naming_convention.Rmd
+++ b/vignettes/naming_convention.Rmd
@@ -23,8 +23,6 @@ library(rtichoke)
 
 ```{r echo=FALSE}
 
-library(magrittr)
-
 tibble::tribble(
   ~"Output", ~"Predictions and Outcomes", ~"Performance Data",
   "Performance Data", "`prepare_performance_data()`", "",
@@ -36,16 +34,16 @@ tibble::tribble(
   "Calibration", "`create_calibration_curve()`", "",
   "Performance Table", "`create_performance_table()`", "`render_performance_table()`",
   "Summary Report", "`create_summary_report()`", ""
-) %>%
-  gt::gt(rowname_col = "Output") %>%
-  gt::fmt_markdown(columns = c("Predictions and Outcomes", "Performance Data")) %>%
+) |>
+  gt::gt(rowname_col = "Output") |>
+  gt::fmt_markdown(columns = c("Predictions and Outcomes", "Performance Data")) |>
   gt::tab_style(
     style = list(
       gt::cell_text(weight = "bold")
     ),
     locations = gt::cells_column_labels(dplyr::everything())
-  ) %>%
-  gt::opt_table_lines(extent = "default") %>%
+  ) |>
+  gt::opt_table_lines(extent = "default") |>
   gt::tab_options(
     column_labels.border.top.color = "white",
     column_labels.border.top.width = gt::px(3),
@@ -66,19 +64,19 @@ tibble::tribble(
   "Gains", "y", " ", " ", "x", " ", " ", " ",
   "Precision Recall", "x", " ", "y", " ", " ", " ", " ",
   "Decision", " ", " ", " ", " ", " ", "y", "x"
-) %>%
-  gt::gt(rowname_col = "Curve") %>%
+) |>
+  gt::gt(rowname_col = "Curve") |>
   #
-  # gt::fmt_markdown(columns = c("Sens", "Spec", "PPV", "PPCR", "Lift", "NB", "P. Thr")) %>%
+  # gt::fmt_markdown(columns = c("Sens", "Spec", "PPV", "PPCR", "Lift", "NB", "P. Thr")) |>
   #
-  # gt::fmt_markdown(columns = everything()) %>%
+  # gt::fmt_markdown(columns = everything()) |>
   gt::tab_style(
     style = list(
       gt::cell_text(weight = "bold")
     ),
     locations = gt::cells_column_labels(dplyr::everything())
-  ) %>%
-  gt::opt_table_lines(extent = "default") %>%
+  ) |>
+  gt::opt_table_lines(extent = "default") |>
   gt::tab_options(
     column_labels.border.top.color = "white",
     column_labels.border.top.width = gt::px(3),
@@ -86,7 +84,7 @@ tibble::tribble(
     table_body.hlines.color = "white",
     table.border.bottom.color = "white",
     table.border.bottom.width = gt::px(3)
-  ) %>%
+  ) |>
   gt::cols_align(
     columns = dplyr::everything(),
     align = "center"


### PR DESCRIPTION
## Summary

- raise the declared minimum supported R version from `R >= 2.10` to `R >= 4.2`
- replace the moving `oldrel-1` R CMD check job with an explicit R 4.2 minimum-version job
- migrate package internals, tests, data-raw scripts, README/vignette examples, roxygen examples, and the summary-report template from `%>%` to native `|>`
- translate magrittr-only brace/placeholder pipelines explicitly where a token-for-token replacement would not preserve semantics

## Compatibility

- keep the exported `%>%` compatibility API in `R/utils-pipe.R` and `NAMESPACE`
- keep `magrittr` in `Imports`
- do not change the public API

## Scope

This is a modernization-only PR. Statistical calculations are intentionally unchanged, and unrelated correctness issues are left for separate PRs. PR #154 remains separate pkgdown infrastructure work.

## Validation

The existing strengthened regression suite and R CMD check matrix should protect behavior, including the new explicit R 4.2 minimum-version job.