### PR TITLE
Prove canonical calibration rendering from real rtichoke output

### DIFF
--- a/.github/workflows/pkgdown-preview.yaml
+++ b/.github/workflows/pkgdown-preview.yaml
@@ -42,6 +42,14 @@ jobs:
           curl -fL "https://raw.githubusercontent.com/uriahf/rtichoke_python/9cfa1e6249f435dd2690fbe297eece4aed766c7a/src/rtichoke/_vendor/rtichoke_viz/rtichoke-viz.css" \
             -o docs/rtichoke-viz-roc/rtichoke-viz.css
 
+      - name: Generate rtichoke_viz calibration proof
+        run: |
+          Rscript scripts/rtichoke_viz_calibration_proof.R
+          curl -fL "https://raw.githubusercontent.com/uriahf/rtichoke_python/9cfa1e6249f435dd2690fbe297eece4aed766c7a/src/rtichoke/_vendor/rtichoke_viz/rtichoke-viz.js" \
+            -o docs/rtichoke-viz-calibration/rtichoke-viz.js
+          curl -fL "https://raw.githubusercontent.com/uriahf/rtichoke_python/9cfa1e6249f435dd2690fbe297eece4aed766c7a/src/rtichoke/_vendor/rtichoke_viz/rtichoke-viz.css" \
+            -o docs/rtichoke-viz-calibration/rtichoke-viz.css
+
       - name: Publish PR preview
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/R/rtichoke_viz.R
+++ b/R/rtichoke_viz.R
@@ -163,7 +163,7 @@ write_rtichoke_viz_roc_proof <- function(performance_data, output_dir) {
   invisible(output_path)
 }
 
-write_rtichoke_viz_calibration_proof <- function(
+write_rtichoke_viz_calib_proof <- function(
   calibration_curve_list,
   output_dir
 ) {

--- a/R/rtichoke_viz.R
+++ b/R/rtichoke_viz.R
@@ -43,6 +43,85 @@ rtichoke_viz_roc_spec <- function(performance_data) {
   )
 }
 
+rtichoke_viz_calibration_spec <- function(calibration_curve_list) {
+  deciles_dat <- calibration_curve_list$deciles_dat
+  histogram <- calibration_curve_list$histogram_for_calibration
+
+  required_decile_columns <- c(
+    "reference_group",
+    "x",
+    "y",
+    "sum_reals",
+    "total_obs"
+  )
+  missing_decile_columns <- setdiff(
+    required_decile_columns,
+    names(deciles_dat)
+  )
+  if (length(missing_decile_columns) > 0) {
+    stop(
+      "Calibration data is missing columns: ",
+      paste(missing_decile_columns, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  required_histogram_columns <- c(
+    "reference_group",
+    "mids",
+    "counts"
+  )
+  missing_histogram_columns <- setdiff(
+    required_histogram_columns,
+    names(histogram)
+  )
+  if (length(missing_histogram_columns) > 0) {
+    stop(
+      "Calibration histogram is missing columns: ",
+      paste(missing_histogram_columns, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  data <- lapply(seq_len(nrow(deciles_dat)), function(i) {
+    list(
+      model = as.character(deciles_dat$reference_group[[i]]),
+      predicted = deciles_dat$x[[i]],
+      observed = deciles_dat$y[[i]],
+      method = "discrete",
+      events = deciles_dat$sum_reals[[i]],
+      total = deciles_dat$total_obs[[i]]
+    )
+  })
+
+  distribution <- lapply(seq_len(nrow(histogram)), function(i) {
+    list(
+      model = as.character(histogram$reference_group[[i]]),
+      midpoint = histogram$mids[[i]],
+      count = histogram$counts[[i]],
+      binWidth = 0.01
+    )
+  })
+
+  list(
+    schemaVersion = "1.0",
+    type = "calibration",
+    data = data,
+    distribution = distribution,
+    x = "predicted",
+    y = "observed",
+    xAxis = list(
+      label = "Predicted probability",
+      domain = c(0, 1)
+    ),
+    yAxis = list(
+      label = "Observed probability",
+      domain = c(0, 1)
+    ),
+    references = list(list(type = "identity"))
+  )
+}
+
 write_rtichoke_viz_roc_proof <- function(performance_data, output_dir) {
   dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
 
@@ -74,6 +153,54 @@ write_rtichoke_viz_roc_proof <- function(performance_data, output_dir) {
     "      document.querySelector(\"#roc-spec\").textContent\n",
     "    );\n",
     "    document.querySelector(\"#roc-chart\").append(renderRoc(spec));\n",
+    "  </script>\n",
+    "</body>\n",
+    "</html>\n"
+  )
+
+  output_path <- file.path(output_dir, "index.html")
+  writeLines(html, output_path, useBytes = TRUE)
+  invisible(output_path)
+}
+
+write_rtichoke_viz_calibration_proof <- function(
+  calibration_curve_list,
+  output_dir
+) {
+  dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+
+  spec_json <- jsonlite::toJSON(
+    rtichoke_viz_calibration_spec(calibration_curve_list),
+    auto_unbox = TRUE,
+    digits = NA
+  )
+  spec_json <- gsub("</", "<\\/", spec_json, fixed = TRUE)
+
+  html <- paste0(
+    "<!doctype html>\n",
+    "<html lang=\"en\">\n",
+    "<head>\n",
+    "  <meta charset=\"utf-8\">\n",
+    "  <meta name=\"viewport\" ",
+    "content=\"width=device-width, initial-scale=1\">\n",
+    "  <title>rtichoke_viz R calibration proof</title>\n",
+    "  <link rel=\"stylesheet\" href=\"./rtichoke-viz.css\">\n",
+    "</head>\n",
+    "<body>\n",
+    "  <div id=\"calibration-chart\" ",
+    "class=\"rtichoke-viz-chart\"></div>\n",
+    "  <script id=\"calibration-spec\" ",
+    "type=\"application/json\">",
+    spec_json,
+    "</script>\n",
+    "  <script type=\"module\">\n",
+    "    import { renderCalibration } ",
+    "from \"./rtichoke-viz.js\";\n",
+    "    const spec = JSON.parse(\n",
+    "      document.querySelector(\"#calibration-spec\").textContent\n",
+    "    );\n",
+    "    document.querySelector(\"#calibration-chart\")\n",
+    "      .append(renderCalibration(spec));\n",
     "  </script>\n",
     "</body>\n",
     "</html>\n"

--- a/scripts/rtichoke_viz_calibration_proof.R
+++ b/scripts/rtichoke_viz_calibration_proof.R
@@ -1,0 +1,14 @@
+library(rtichoke)
+
+calibration_curve_list <- create_calibration_curve_list(
+  probs = list(
+    "Estimated model" = example_dat$estimated_probabilities,
+    "Random guess" = example_dat$random_guess
+  ),
+  reals = list(example_dat$outcome)
+)
+
+rtichoke:::write_rtichoke_viz_calibration_proof(
+  calibration_curve_list,
+  file.path("docs", "rtichoke-viz-calibration")
+)

--- a/scripts/rtichoke_viz_calibration_proof.R
+++ b/scripts/rtichoke_viz_calibration_proof.R
@@ -8,7 +8,7 @@ calibration_curve_list <- create_calibration_curve_list(
   reals = list(example_dat$outcome)
 )
 
-rtichoke:::write_rtichoke_viz_calibration_proof(
+rtichoke:::write_rtichoke_viz_calib_proof(
   calibration_curve_list,
   file.path("docs", "rtichoke-viz-calibration")
 )

--- a/tests/testthat/test-rtichoke-viz.R
+++ b/tests/testthat/test-rtichoke-viz.R
@@ -39,3 +39,38 @@ test_that("ROC spec rejects incomplete performance data", {
     "probability_threshold, specificity"
   )
 })
+
+test_that("real calibration output maps to the canonical viz spec", {
+  calibration_curve_list <- create_calibration_curve_list(
+    probs = list(
+      "Estimated model" = example_dat$estimated_probabilities,
+      "Random guess" = example_dat$random_guess
+    ),
+    reals = list(example_dat$outcome)
+  )
+
+  spec <- rtichoke_viz_calibration_spec(calibration_curve_list)
+
+  expect_identical(spec$schemaVersion, "1.0")
+  expect_identical(spec$type, "calibration")
+  expect_identical(spec$x, "predicted")
+  expect_identical(spec$y, "observed")
+  expect_length(
+    spec$data,
+    nrow(calibration_curve_list$deciles_dat)
+  )
+  expect_length(
+    spec$distribution,
+    nrow(calibration_curve_list$histogram_for_calibration)
+  )
+  expect_setequal(
+    unique(vapply(spec$data, `[[`, character(1), "model")),
+    c("Estimated model", "Random guess")
+  )
+
+  first_decile <- calibration_curve_list$deciles_dat[1, ]
+  expect_identical(spec$data[[1]]$predicted, first_decile$x[[1]])
+  expect_identical(spec$data[[1]]$observed, first_decile$y[[1]])
+  expect_identical(spec$data[[1]]$events, first_decile$sum_reals[[1]])
+  expect_identical(spec$data[[1]]$total, first_decile$total_obs[[1]])
+})


### PR DESCRIPTION
## Goal

Prove that real `rtichoke` R discrete calibration output maps to the same canonical `rtichoke_viz` calibration spec already used by `rtichoke_python`, and renders with the same compiled browser renderer.

## Included

- add an internal adapter from existing `create_calibration_curve_list()` output to the canonical calibration spec
- preserve existing ggplot2 and Plotly calibration paths unchanged
- map `sum_reals` / `total_obs` to canonical `events` / `total`
- map the existing calibration histogram to the canonical distribution records
- add focused tests using real `rtichoke` example data
- add a small browser-proof script using two real model series
- publish the proof in the existing pkgdown PR preview
- reuse the same compiled `rtichoke_viz` JS/CSS pinned from the Python integration for preview generation only

No statistical behavior changes. No public API changes. No compiled assets are added to the R package in this PR.

## Rendered preview

https://uriahf.github.io/rtichoke/pr-preview/pr-157/rtichoke-viz-calibration/
