### PR TITLE
Tighten namespace import declarations

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -18,12 +18,23 @@ export(plot_roc_curve)
 export(prepare_performance_data)
 export(render_performance_table)
 import(dplyr)
-import(htmltools)
-import(rlang)
 importFrom(crosstalk,SharedData)
 importFrom(graphics,text)
+importFrom(htmltools,
+  attachDependencies,
+  htmlDependency,
+  span,
+  tagList,
+  tags
+)
 importFrom(magrittr,"%>%")
 importFrom(pROC,auc)
+importFrom(rlang,
+  ":=",
+  .data,
+  enquo,
+  sym
+)
 importFrom(stats,
   approx,
   as.formula,

--- a/R/script_for_dependencies.R
+++ b/R/script_for_dependencies.R
@@ -1,7 +1,7 @@
 # Suppress R CMD check note
-#' @import htmltools
 #' @import dplyr
-#' @importFrom stats quantile as.formula
-#' @import rlang
 #' @importFrom crosstalk SharedData
+#' @importFrom htmltools attachDependencies htmlDependency span tagList tags
+#' @importFrom rlang .data := enquo sym
+#' @importFrom stats quantile as.formula
 NULL


### PR DESCRIPTION
## Summary

- replace broad `htmltools` and `rlang` namespace imports with explicit `@importFrom` declarations
- regenerate `NAMESPACE` accordingly
- keep the existing broad `dplyr` import because package code still relies on many unqualified dplyr verbs
- keep all current runtime dependencies, including `lazyeval`, after confirming they are still used

## Scope

Namespace/developer hygiene only. No statistical calculations, public APIs, return values, plotting behavior, or package dependencies are changed.

## Notes

This intentionally leaves the exported `%>%` compatibility API and `magrittr` untouched. A broader dplyr qualification pass would be a separate modernization batch rather than expanding this PR.