### PR TITLE
Modernize CRAN-facing package metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,16 @@
 Package: rtichoke
-Title: rtichoke
+Title: Interactive Visualization of Binary Prediction Model Performance
 Version: 0.0.7
 Authors@R: 
     person("Uriah", "Finkel", , "ufinkel@gmail.com", role = c("cre", "aut"))
-Description: Interactive visualization for model performance.
+Description: Tools for exploring the performance of prediction models with
+    binary outcomes through interactive and static visualizations. Supports
+    receiver operating characteristic, precision-recall, gains, lift,
+    decision, and calibration curves, together with performance tables and
+    summary reports.
 License: MIT + file LICENSE
-URL: https://github.com/uriahf/rtichoke
+URL: https://uriahf.github.io/rtichoke/,
+    https://github.com/uriahf/rtichoke
 BugReports: https://github.com/uriahf/rtichoke/issues
 Depends: 
     R (>= 4.2)

--- a/R/calibration.R
+++ b/R/calibration.R
@@ -132,7 +132,7 @@ create_calibration_curve <- function(
 
 #' Define limits for Calibration Curve
 #'
-#' @param deciles_dat
+#' @param deciles_dat A data frame containing decile-level calibration data.
 #'
 #' @keywords internal
 #' @examples

--- a/man/define_limits_for_calibration_plot.Rd
+++ b/man/define_limits_for_calibration_plot.Rd
@@ -6,6 +6,9 @@
 \usage{
 define_limits_for_calibration_plot(deciles_dat)
 }
+\arguments{
+\item{deciles_dat}{A data frame containing decile-level calibration data.}
+}
 \description{
 Define limits for Calibration Curve
 }

--- a/man/rtichoke-package.Rd
+++ b/man/rtichoke-package.Rd
@@ -4,12 +4,9 @@
 \name{rtichoke-package}
 \alias{rtichoke}
 \alias{rtichoke-package}
-\title{rtichoke: Interactive Evaluation of Binary Prediction Models}
+\title{rtichoke: Interactive Visualization of Binary Prediction Model Performance}
 \description{
-Interactive tools for evaluating binary prediction-model performance. Provides
-visualizations and summaries for receiver operating characteristic and
-precision-recall curves, gains and lift charts, decision curves, calibration,
-confusion matrices, model metrics, and related performance reports.
+Tools for exploring the performance of prediction models with binary outcomes through interactive and static visualizations. Supports receiver operating characteristic, precision-recall, gains, lift, decision, and calibration curves, together with performance tables and summary reports.
 }
 \seealso{
 Useful links:

--- a/man/rtichoke-package.Rd
+++ b/man/rtichoke-package.Rd
@@ -4,13 +4,17 @@
 \name{rtichoke-package}
 \alias{rtichoke}
 \alias{rtichoke-package}
-\title{rtichoke: rtichoke}
+\title{rtichoke: Interactive Evaluation of Binary Prediction Models}
 \description{
-Interactive visualization for model performance.
+Interactive tools for evaluating binary prediction-model performance. Provides
+visualizations and summaries for receiver operating characteristic and
+precision-recall curves, gains and lift charts, decision curves, calibration,
+confusion matrices, model metrics, and related performance reports.
 }
 \seealso{
 Useful links:
 \itemize{
+  \item \url{https://uriahf.github.io/rtichoke/}
   \item \url{https://github.com/uriahf/rtichoke}
   \item Report bugs at \url{https://github.com/uriahf/rtichoke/issues}
 }


### PR DESCRIPTION
## Summary

- replace the placeholder package title with a descriptive title for binary prediction-model performance visualization
- expand the package description to reflect the existing ROC, precision-recall, gains, lift, decision, calibration, table, and report functionality
- add the pkgdown site to the package `URL` field while retaining the GitHub repository
- regenerate the package-level documentation affected by the metadata changes
- fix a pre-existing incomplete `@param deciles_dat` roxygen tag exposed by documentation regeneration

## Scope

This is a metadata/documentation maintenance change. No statistical calculations, public APIs, dependencies, tests, or plotting behavior are changed.

## Audit notes

The existing author, license, minimum R version, encoding, testthat, roxygen, and vignette metadata are left unchanged. This PR does not include a version bump or any CRAN submission-specific changes.