### PR TITLE
Make /document reliably fix documentation drift

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -14,7 +14,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/pr-fetch@v2
         with:
@@ -31,14 +31,21 @@ jobs:
       - name: Document
         run: Rscript -e 'roxygen2::roxygenise()'
 
-      - name: commit
+      - name: Commit documentation
+        id: commit-documentation
         run: |
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git add man/\* NAMESPACE
+          git add -- DESCRIPTION NAMESPACE man
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           git commit -m 'Document'
+          echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - uses: r-lib/actions/pr-push@v2
+        if: steps.commit-documentation.outputs.changed == 'true'
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -32,7 +32,7 @@ jobs:
         run: Rscript -e 'roxygen2::roxygenise()'
 
       - name: Commit documentation
-        id: commit-documentation
+        id: commit_documentation
         run: |
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
@@ -45,7 +45,7 @@ jobs:
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - uses: r-lib/actions/pr-push@v2
-        if: steps.commit-documentation.outputs.changed == 'true'
+        if: steps.commit_documentation.outputs.changed == 'true'
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- update the `/document` job to `actions/checkout@v6`
- stage the same roxygen-managed outputs enforced by documentation CI: `DESCRIPTION`, `NAMESPACE`, and `man/`
- make no-op documentation runs succeed without creating an empty commit
- only invoke `pr-push` when roxygen actually changed generated files

## Scope

Infrastructure-only. The existing documentation drift check remains unchanged. No statistical calculations, package APIs, package metadata, generated documentation, or unrelated code are modified.

## Intended workflow

`edit source/package metadata → /document → CI`

`/document` now regenerates and pushes every generated path that the documentation CI verifies, so documentation drift failures have a single reliable automatic remedy.