### PR TITLE
ci: reduce wasted PR work

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,6 +10,10 @@ name: R-CMD-check
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   R-CMD-check:
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -11,6 +11,10 @@ name: documentation
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   documentation:
     runs-on: ubuntu-latest

--- a/.github/workflows/pkgdown-preview.yaml
+++ b/.github/workflows/pkgdown-preview.yaml
@@ -3,6 +3,19 @@ name: pkgdown preview
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
+    paths:
+      - "R/**"
+      - "man/**"
+      - "vignettes/**"
+      - "inst/**"
+      - "data/**"
+      - "scripts/**"
+      - "DESCRIPTION"
+      - "NAMESPACE"
+      - "README.md"
+      - "NEWS.md"
+      - "_pkgdown.yml"
+      - ".github/workflows/pkgdown-preview.yaml"
 
 permissions:
   contents: write
@@ -19,7 +32,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       RTICHOKE_VIZ_VERSION: "0.1.0"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -89,7 +102,7 @@ jobs:
     if: github.event.action == 'closed'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Remove PR preview
         env:

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -5,6 +5,10 @@ name: style
 
 permissions: read-all
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   style:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -3,11 +3,33 @@
 on:
   push:
     branches: [main]
+    paths:
+      - "R/**"
+      - "tests/**"
+      - "src/**"
+      - "inst/**"
+      - "data/**"
+      - "DESCRIPTION"
+      - "NAMESPACE"
+      - ".github/workflows/test-coverage.yaml"
   pull_request:
+    paths:
+      - "R/**"
+      - "tests/**"
+      - "src/**"
+      - "inst/**"
+      - "data/**"
+      - "DESCRIPTION"
+      - "NAMESPACE"
+      - ".github/workflows/test-coverage.yaml"
 
 name: test-coverage
 
 permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test-coverage:


### PR DESCRIPTION
## Summary

- cancel superseded R CMD check, documentation, style, and coverage runs
- run coverage only when package/test inputs change
- run pkgdown previews only for website-relevant changes while preserving the existing serialized `gh-pages` deployment
- update remaining pkgdown checkout actions to `actions/checkout@v6`

## Scope

This is Phase 1 only. It does **not** reduce the R CMD check matrix or change package behavior, statistical calculations, or public APIs.

## Rationale

The current PR workflow repeats expensive work on obsolete commits and builds previews for changes that cannot affect the site. These changes remove that waste without weakening the full validation matrix.
