### PR TITLE
chore: finish pkgdown deployment hardening

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -7,6 +7,13 @@ on:
 
 name: pkgdown
 
+permissions:
+  contents: write
+
+concurrency:
+  group: pkgdown-pages
+  cancel-in-progress: false
+
 jobs:
   pkgdown:
     runs-on: ubuntu-latest

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,3 @@
-url: ~
+url: https://uriahf.github.io/rtichoke/
 template:
   bootstrap: 5
-


### PR DESCRIPTION
## Summary

- configure the canonical pkgdown site URL in `_pkgdown.yml`
- give the main pkgdown deploy explicit `contents: write` permission
- serialize the main deploy with the existing `pkgdown-pages` concurrency group

## Scope

Infrastructure/documentation configuration only. No package metadata, generated documentation, statistical calculations, public APIs, or package behavior change.

## Context

These are the still-relevant pieces from stale draft PR #154. Later PRs already landed its checkout and package-metadata updates, so this replacement keeps only the residual work.