### PR TITLE
Clean up internal crosstalk helpers

### DIFF
--- a/R/functions_for_crosstalk.R
+++ b/R/functions_for_crosstalk.R
@@ -67,13 +67,11 @@ makeGroupOptions_rtichoke <- function(sharedData, group, allLevels,
     sort(unique(group))
   }
   matches <- match(group, lvls)
-  vals <- lapply(seq_len(length(lvls)), function(i) {
+  vals <- lapply(seq_along(lvls), function(i) {
     df$key_[which(matches == i)]
   })
 
   lvls_str <- as.character(lvls)
-
-  # print(lvls_str)
 
   options <- list(
     items = data.frame(
@@ -85,7 +83,6 @@ makeGroupOptions_rtichoke <- function(sharedData, group, allLevels,
     group = sharedData$groupName()
   )
 
-  # print(options)
   options
 }
 
@@ -97,7 +94,6 @@ inlineCheckbox <- function(id, value, label) {
   )
 }
 
-
 jqueryLib <- function() {
   htmlDependency(
     name = "jquery",
@@ -107,7 +103,6 @@ jqueryLib <- function() {
     script = "jquery.min.js"
   )
 }
-
 
 columnize <- function(columnCount, elements) {
   if (columnCount <= 1 || length(elements) <= 1) {


### PR DESCRIPTION
## Summary

- remove commented-out debug remnants from the internal crosstalk helper
- use `seq_along()` instead of `seq_len(length(...))`
- keep behavior, calculations, APIs, dependencies, and generated documentation unchanged

## Scope

Internal hygiene only. No statistical calculations, plotting semantics, reference-line behavior, public APIs, package metadata, or dependencies are changed.