### PR TITLE
Add internal evaluation semantic metadata

### DIFF
--- a/R/evaluation_semantics.R
+++ b/R/evaluation_semantics.R
@@ -1,0 +1,64 @@
+#' Build evaluation semantic metadata
+#'
+#' Derive stable internal model, population, and evaluation identities from the
+#' existing `probs`/`reals` input shapes. This formalizes semantics without
+#' changing public APIs or production plotting behavior.
+#'
+#' @param probs A list of model predictions.
+#' @param reals A list of observed outcomes.
+#'
+#' @return A data frame with one row per evaluation and `model`, `population`,
+#'   and `evaluation` columns.
+#' @keywords internal
+build_evaluation_metadata <- function(probs, reals) {
+  probs_names <- names(probs)
+  reals_names <- names(reals)
+
+  if (length(reals) == 1L) {
+    population <- if (!is.null(reals_names) && nzchar(reals_names[[1]])) {
+      reals_names[[1]]
+    } else {
+      "population"
+    }
+
+    model <- if (!is.null(probs_names)) {
+      probs_names
+    } else if (length(probs) == 1L) {
+      "model"
+    } else {
+      paste0("model_", seq_along(probs))
+    }
+
+    model[is.na(model) | !nzchar(model)] <- paste0(
+      "model_",
+      which(is.na(model) | !nzchar(model))
+    )
+
+    return(data.frame(
+      model = model,
+      population = rep(population, length(probs)),
+      evaluation = model,
+      stringsAsFactors = FALSE
+    ))
+  }
+
+  evaluation <- if (!is.null(probs_names)) {
+    probs_names
+  } else if (!is.null(reals_names)) {
+    reals_names
+  } else {
+    paste0("evaluation_", seq_along(probs))
+  }
+
+  evaluation[is.na(evaluation) | !nzchar(evaluation)] <- paste0(
+    "evaluation_",
+    which(is.na(evaluation) | !nzchar(evaluation))
+  )
+
+  data.frame(
+    model = evaluation,
+    population = evaluation,
+    evaluation = evaluation,
+    stringsAsFactors = FALSE
+  )
+}

--- a/tests/testthat/test-evaluation-semantics.R
+++ b/tests/testthat/test-evaluation-semantics.R
@@ -1,0 +1,57 @@
+test_that("one model and one population have one evaluation", {
+  metadata <- rtichoke:::build_evaluation_metadata(
+    probs = list(c(0.1, 0.9)),
+    reals = list(c(0, 1))
+  )
+
+  expect_identical(metadata$model, "model")
+  expect_identical(metadata$population, "population")
+  expect_identical(metadata$evaluation, "model")
+})
+
+test_that("multiple models share stable population identity", {
+  metadata <- rtichoke:::build_evaluation_metadata(
+    probs = list(
+      "Model A" = c(0.1, 0.9),
+      "Model B" = c(0.2, 0.8)
+    ),
+    reals = list("Population A" = c(0, 1))
+  )
+
+  expect_identical(metadata$model, c("Model A", "Model B"))
+  expect_identical(metadata$population, c("Population A", "Population A"))
+  expect_identical(metadata$evaluation, c("Model A", "Model B"))
+})
+
+test_that("keyed populations retain distinct identities", {
+  metadata <- rtichoke:::build_evaluation_metadata(
+    probs = list(
+      "Population A" = c(0.1, 0.9),
+      "Population B" = c(0.2, 0.8)
+    ),
+    reals = list(
+      "Population A" = c(0, 1),
+      "Population B" = c(0, 1)
+    )
+  )
+
+  expect_identical(metadata$population, c("Population A", "Population B"))
+  expect_identical(metadata$evaluation, c("Population A", "Population B"))
+})
+
+test_that("paired inputs preserve evaluation labels", {
+  pair_names <- c("Model A @ Population A", "Model B @ Population B")
+  metadata <- rtichoke:::build_evaluation_metadata(
+    probs = stats::setNames(
+      list(c(0.1, 0.9), c(0.2, 0.8)),
+      pair_names
+    ),
+    reals = stats::setNames(
+      list(c(0, 1), c(0, 1)),
+      pair_names
+    )
+  )
+
+  expect_identical(metadata$population, pair_names)
+  expect_identical(metadata$evaluation, pair_names)
+})


### PR DESCRIPTION
## Goal

Add an internal semantic representation of `model`, `population`, and `evaluation` identities analogous to the metadata introduced in `rtichoke_python` #369.

## Why

The semantic audit and characterization tests show that R already has the desired reference-line ownership behavior, including keeping distinct equal-prevalence populations as distinct reference owners. No production behavior change is needed.

This PR only makes those already-established concepts explicit internally so future cross-language work can reason about the same semantic vocabulary.

## Scope

- add internal `build_evaluation_metadata()` helper;
- characterize one model / one population;
- characterize multiple models sharing one population;
- characterize distinct keyed populations, including equal-outcome examples;
- characterize explicitly paired evaluation labels.

## Non-goals

- no statistical changes;
- no public API changes;
- no plotting or reference-line behavior changes;
- production code does not consume this metadata yet;
- no `rtichoke_viz` changes.
