### PR TITLE
Align keyed evaluation model semantics

### DIFF
--- a/R/evaluation_semantics.R
+++ b/R/evaluation_semantics.R
@@ -56,7 +56,7 @@ build_evaluation_metadata <- function(probs, reals) {
   )
 
   data.frame(
-    model = evaluation,
+    model = rep(NA_character_, length(evaluation)),
     population = evaluation,
     evaluation = evaluation,
     stringsAsFactors = FALSE

--- a/tests/testthat/test-evaluation-semantics.R
+++ b/tests/testthat/test-evaluation-semantics.R
@@ -35,11 +35,12 @@ test_that("keyed populations retain distinct identities", {
     )
   )
 
+  expect_true(all(is.na(metadata$model)))
   expect_identical(metadata$population, c("Population A", "Population B"))
   expect_identical(metadata$evaluation, c("Population A", "Population B"))
 })
 
-test_that("paired inputs preserve evaluation labels", {
+test_that("paired inputs preserve evaluation labels without guessing model", {
   pair_names <- c("Model A @ Population A", "Model B @ Population B")
   metadata <- rtichoke:::build_evaluation_metadata(
     probs = stats::setNames(
@@ -52,6 +53,7 @@ test_that("paired inputs preserve evaluation labels", {
     )
   )
 
+  expect_true(all(is.na(metadata$model)))
   expect_identical(metadata$population, pair_names)
   expect_identical(metadata$evaluation, pair_names)
 })


### PR DESCRIPTION
## Goal

Align R's new internal evaluation metadata with the semantic contract already represented in `rtichoke_python`.

For keyed population/evaluation inputs, the existing API identifies an evaluation/population label but does not separately encode model identity. The internal metadata should therefore record the model as unknown rather than infer it from that generic label.

## Change

- keyed evaluations now use `NA_character_` for internal `model` identity;
- `population` and `evaluation` continue to preserve the compatibility label;
- tests explicitly cover keyed populations and paired labels.

## Scope

Internal semantic metadata only. No public API, statistical calculation, plotting, reference-line behavior, output semantics, or `rtichoke_viz` changes.
