### PR TITLE
Tighten dplyr namespace imports

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -17,8 +17,34 @@ export(plot_precision_recall_curve)
 export(plot_roc_curve)
 export(prepare_performance_data)
 export(render_performance_table)
-import(dplyr)
 importFrom(crosstalk,SharedData)
+importFrom(dplyr,
+  across,
+  all_of,
+  arrange,
+  bind_cols,
+  bind_rows,
+  case_when,
+  count,
+  desc,
+  distinct,
+  everything,
+  filter,
+  first,
+  group_by,
+  if_else,
+  left_join,
+  mutate,
+  n,
+  pull,
+  recode,
+  rename,
+  row_number,
+  select,
+  slice,
+  summarise,
+  ungroup
+)
 importFrom(graphics,text)
 importFrom(htmltools,
   attachDependencies,

--- a/R/script_for_dependencies.R
+++ b/R/script_for_dependencies.R
@@ -1,5 +1,8 @@
 # Suppress R CMD check note
-#' @import dplyr
+#' @importFrom dplyr across all_of arrange bind_cols bind_rows case_when
+#' @importFrom dplyr count desc distinct everything filter first group_by
+#' @importFrom dplyr if_else left_join mutate n pull recode rename row_number
+#' @importFrom dplyr select slice summarise ungroup
 #' @importFrom crosstalk SharedData
 #' @importFrom htmltools attachDependencies htmlDependency span tagList tags
 #' @importFrom rlang .data := enquo sym


### PR DESCRIPTION
## Summary

- replace the broad `import(dplyr)` namespace declaration with explicit `dplyr` imports used by package internals
- regenerate `NAMESPACE` accordingly
- keep `dplyr` in `Imports`

## Scope

Namespace/developer hygiene only. No statistical calculations, public APIs, output semantics, package dependencies, or `rtichoke_viz` are changed.

## Rationale

This completes the namespace-hygiene direction started in #158 while keeping the change smaller and safer than a package-wide call-site rewrite. A future qualification pass can be considered separately if it still provides enough value.