### PR TITLE
Fix CRAN validation artifact directory

### DIFF
--- a/.github/workflows/cran-check.yaml
+++ b/.github/workflows/cran-check.yaml
@@ -26,6 +26,7 @@ jobs:
       - name: Build source package
         shell: Rscript {0}
         run: |
+          dir.create("cran-artifacts", showWarnings = FALSE)
           pkg <- pkgbuild::build(path = ".", dest_path = "cran-artifacts")
           writeLines(pkg, "cran-artifacts/tarball-path.txt")
 


### PR DESCRIPTION
## Summary

Fixes the first manual CRAN-validation run by creating `cran-artifacts/` before passing it to `pkgbuild::build()` and writing `tarball-path.txt`.

The initial run failed in workflow plumbing before `R CMD check --as-cran` was reached, so this is not a package/CRAN finding.

## Scope

One-line infrastructure fix only. No package code, API, statistical calculations, output semantics, dependencies, version, or `rtichoke_viz` changes.

After merge, rerun **CRAN validation** manually on `main` to obtain the first actual CRAN-style check result.