### PR TITLE
Vendor rtichoke_viz v0.2.0 release

### DIFF
--- a/.github/workflows/pkgdown-preview.yaml
+++ b/.github/workflows/pkgdown-preview.yaml
@@ -31,6 +31,10 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       RTICHOKE_VIZ_VERSION: "0.2.0"
+      RTICHOKE_VIZ_RELEASE_TAG: "v0.2.0"
+      RTICHOKE_VIZ_SOURCE_COMMIT: "45dc109a6a0679d0f8f3f9452d8de9306a89b906"
+      RTICHOKE_VIZ_ARCHIVE: "rtichoke-viz-0.2.0.tar.gz"
+      RTICHOKE_VIZ_SHA256: "3861277c01b3983f8b344a9ee0237c7d09fd0ba4c3d1e0cce489962e7b559d9f"
     steps:
       - uses: actions/checkout@v6
 
@@ -50,21 +54,23 @@ jobs:
 
       - name: Download rtichoke_viz browser bundle
         run: |
-          VERSION="${RTICHOKE_VIZ_VERSION}"
-          BUNDLE="rtichoke-viz-${VERSION}"
-          BASE_URL="https://github.com/uriahf/rtichoke_viz/releases/download/v${VERSION}"
+          BUNDLE="rtichoke-viz-${RTICHOKE_VIZ_VERSION}"
+          BASE_URL="https://github.com/uriahf/rtichoke_viz/releases/download/${RTICHOKE_VIZ_RELEASE_TAG}"
           mkdir -p /tmp/rtichoke-viz
-          curl -fL "${BASE_URL}/${BUNDLE}.tar.gz" \
-            -o "/tmp/rtichoke-viz/${BUNDLE}.tar.gz"
-          curl -fL "${BASE_URL}/${BUNDLE}.tar.gz.sha256" \
-            -o "/tmp/rtichoke-viz/${BUNDLE}.tar.gz.sha256"
+          curl -fL "${BASE_URL}/${RTICHOKE_VIZ_ARCHIVE}" \
+            -o "/tmp/rtichoke-viz/${RTICHOKE_VIZ_ARCHIVE}"
+          curl -fL "${BASE_URL}/${RTICHOKE_VIZ_ARCHIVE}.sha256" \
+            -o "/tmp/rtichoke-viz/${RTICHOKE_VIZ_ARCHIVE}.sha256"
           cd /tmp/rtichoke-viz
-          EXPECTED="$(awk '{print $1}' "${BUNDLE}.tar.gz.sha256")"
-          ACTUAL="$(sha256sum "${BUNDLE}.tar.gz" | awk '{print $1}')"
+          EXPECTED="$(awk '{print $1}' "${RTICHOKE_VIZ_ARCHIVE}.sha256")"
+          ACTUAL="$(sha256sum "${RTICHOKE_VIZ_ARCHIVE}" | awk '{print $1}')"
+          echo "rtichoke_viz release tag: ${RTICHOKE_VIZ_RELEASE_TAG}"
+          echo "rtichoke_viz source commit: ${RTICHOKE_VIZ_SOURCE_COMMIT}"
+          echo "rtichoke_viz archive: ${RTICHOKE_VIZ_ARCHIVE}"
           echo "rtichoke_viz archive SHA-256: ${ACTUAL}"
-          printf '%s\n' "${ACTUAL}" > "${GITHUB_WORKSPACE}/docs/rtichoke-viz-archive.sha256"
           test "${ACTUAL}" = "${EXPECTED}"
-          tar -xzf "${BUNDLE}.tar.gz"
+          test "${ACTUAL}" = "${RTICHOKE_VIZ_SHA256}"
+          tar -xzf "${RTICHOKE_VIZ_ARCHIVE}"
           test -f "${BUNDLE}/rtichoke-viz.js"
           test -f "${BUNDLE}/rtichoke-viz.css"
           test -f "${BUNDLE}/rtichoke-viz.schema.json"

--- a/.github/workflows/pkgdown-preview.yaml
+++ b/.github/workflows/pkgdown-preview.yaml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      RTICHOKE_VIZ_VERSION: "0.1.0"
+      RTICHOKE_VIZ_VERSION: "0.2.0"
     steps:
       - uses: actions/checkout@v6
 
@@ -61,8 +61,18 @@ jobs:
           cd /tmp/rtichoke-viz
           EXPECTED="$(awk '{print $1}' "${BUNDLE}.tar.gz.sha256")"
           ACTUAL="$(sha256sum "${BUNDLE}.tar.gz" | awk '{print $1}')"
+          echo "rtichoke_viz archive SHA-256: ${ACTUAL}"
           test "${ACTUAL}" = "${EXPECTED}"
           tar -xzf "${BUNDLE}.tar.gz"
+          test -f "${BUNDLE}/rtichoke-viz.js"
+          test -f "${BUNDLE}/rtichoke-viz.css"
+          test -f "${BUNDLE}/rtichoke-viz.schema.json"
+          test -f "${BUNDLE}/rtichoke-viz-v2.schema.json"
+          test -f "${BUNDLE}/MANIFEST"
+          grep -Fq 'https://rtichoke.dev/schema/viz/1.0.json' \
+            "${BUNDLE}/rtichoke-viz.schema.json"
+          grep -Fq 'https://rtichoke.dev/schema/viz/2.0.json' \
+            "${BUNDLE}/rtichoke-viz-v2.schema.json"
 
       - name: Generate rtichoke_viz ROC proof
         run: |

--- a/.github/workflows/pkgdown-preview.yaml
+++ b/.github/workflows/pkgdown-preview.yaml
@@ -62,6 +62,7 @@ jobs:
           EXPECTED="$(awk '{print $1}' "${BUNDLE}.tar.gz.sha256")"
           ACTUAL="$(sha256sum "${BUNDLE}.tar.gz" | awk '{print $1}')"
           echo "rtichoke_viz archive SHA-256: ${ACTUAL}"
+          printf '%s\n' "${ACTUAL}" > "${GITHUB_WORKSPACE}/docs/rtichoke-viz-archive.sha256"
           test "${ACTUAL}" = "${EXPECTED}"
           tar -xzf "${BUNDLE}.tar.gz"
           test -f "${BUNDLE}/rtichoke-viz.js"


### PR DESCRIPTION
## Summary

Update the existing pkgdown/browser-proof vendoring path from the immutable `rtichoke_viz v0.1.0` release to the immutable `v0.2.0` release.

- pin `RTICHOKE_VIZ_VERSION` to `0.2.0`;
- record the immutable release tag, source commit, archive filename, and verified SHA-256 in CI;
- continue downloading the release archive plus its `.sha256` sidecar;
- verify the computed archive SHA-256 against both the published checksum and the recorded value;
- verify the archive contains JS, CSS, v1 schema, v2 schema, and MANIFEST;
- verify both canonical schema `$id` values;
- keep the existing ROC and calibration production/browser proofs on v1 specs.

## Provenance

- release tag: `v0.2.0`
- source commit: `45dc109a6a0679d0f8f3f9452d8de9306a89b906`
- archive: `rtichoke-viz-0.2.0.tar.gz`
- SHA-256: `3861277c01b3983f8b344a9ee0237c7d09fd0ba4c3d1e0cce489962e7b559d9f`
- v1 schema `$id`: `https://rtichoke.dev/schema/viz/1.0.json`
- v2 schema `$id`: `https://rtichoke.dev/schema/viz/2.0.json`

The `v0.2.0` tag resolves to the source commit above. The release archive checksum was computed from the downloaded immutable release asset in CI and matched the release `.sha256` sidecar.

## Compatibility proof

The first v0.2.0 verification run completed successfully with the existing v1 ROC and calibration spec builders unchanged, including both browser proof-generation steps. This demonstrates that the v0.2.0 bundle remains a drop-in replacement for the current v1 integration.

## Scope

Vendoring/provenance only. No production spec is migrated to v2 in this PR.