### PR TITLE
Make pkgdown logo clearly visible

### DIFF
--- a/pkgdown/extra.css
+++ b/pkgdown/extra.css
@@ -55,6 +55,38 @@ a:focus {
   color: var(--rtichoke-accent) !important;
 }
 
+.page-header {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  margin-bottom: 1.5rem;
+}
+
+.page-header .logo {
+  display: block;
+  width: 180px;
+  height: 180px;
+  max-width: 32vw;
+  object-fit: contain;
+  flex: 0 0 auto;
+}
+
+.page-header h1 {
+  margin: 0;
+}
+
+@media (max-width: 576px) {
+  .page-header {
+    align-items: flex-start;
+    gap: 0.9rem;
+  }
+
+  .page-header .logo {
+    width: 110px;
+    height: 110px;
+  }
+}
+
 pre,
 .sourceCode,
 .card,


### PR DESCRIPTION
## Summary

- explicitly size the existing package logo in the pkgdown page header
- keep the current rtichoke blog-inspired styling unchanged
- add a smaller responsive size on narrow screens

The logo is already emitted by pkgdown as `.page-header .logo`; this PR only makes that existing element clearly visible rather than relying on pkgdown's default sizing.