### PR TITLE
Add internal canonical ROC v2 spec builder

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -39,7 +39,5 @@ jobs:
         shell: bash
         run: |
           while IFS= read -r file; do
-            air format "$file"
+            air format "$file" --check
           done < changed-r-files.txt
-          git diff -- '*.R'
-          git diff --exit-code -- '*.R'

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -39,5 +39,7 @@ jobs:
         shell: bash
         run: |
           while IFS= read -r file; do
-            air format "$file" --check
+            air format "$file"
           done < changed-r-files.txt
+          git diff -- '*.R'
+          git diff --exit-code -- '*.R'

--- a/R/rtichoke_viz_v2.R
+++ b/R/rtichoke_viz_v2.R
@@ -9,7 +9,7 @@
 #' @param evaluation_metadata Output from [build_evaluation_metadata()].
 #'
 #' @return A nested list representing a canonical ROC v2 specification.
-#' @keywords internal
+#' @noRd
 rtichoke_viz_roc_v2_spec <- function(
   performance_data,
   evaluation_metadata

--- a/R/rtichoke_viz_v2.R
+++ b/R/rtichoke_viz_v2.R
@@ -1,0 +1,163 @@
+#' Build a canonical rtichoke_viz v2 ROC specification
+#'
+#' Translate already-computed ROC performance data plus explicit semantic
+#' evaluation metadata into the canonical rtichoke_viz v2 contract. This
+#' helper is deliberately internal and is not wired into production rendering
+#' yet.
+#'
+#' @param performance_data Output from [prepare_performance_data()].
+#' @param evaluation_metadata Output from [build_evaluation_metadata()].
+#'
+#' @return A nested list representing a canonical ROC v2 specification.
+#' @keywords internal
+rtichoke_viz_roc_v2_spec <- function(
+  performance_data,
+  evaluation_metadata
+) {
+  required_columns <- c(
+    "probability_threshold",
+    "sensitivity",
+    "specificity"
+  )
+  missing_columns <- setdiff(required_columns, names(performance_data))
+  if (length(missing_columns) > 0L) {
+    stop(
+      "ROC performance data is missing columns: ",
+      paste(missing_columns, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  required_metadata <- c("model", "population", "evaluation")
+  missing_metadata <- setdiff(required_metadata, names(evaluation_metadata))
+  if (length(missing_metadata) > 0L) {
+    stop(
+      "ROC evaluation metadata is missing columns: ",
+      paste(missing_metadata, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  if (nrow(evaluation_metadata) == 0L) {
+    stop("ROC evaluation metadata must contain at least one evaluation", call. = FALSE)
+  }
+
+  compatibility_group <- roc_v2_compatibility_group(
+    performance_data,
+    evaluation_metadata
+  )
+  metadata_group <- as.character(evaluation_metadata$evaluation)
+
+  missing_groups <- setdiff(unique(compatibility_group), metadata_group)
+  if (length(missing_groups) > 0L) {
+    stop(
+      "ROC performance rows are missing evaluation metadata: ",
+      paste(missing_groups, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  used_metadata <- evaluation_metadata[
+    evaluation_metadata$evaluation %in% unique(compatibility_group),
+    ,
+    drop = FALSE
+  ]
+  used_groups <- as.character(used_metadata$evaluation)
+
+  evaluation_ids <- stats::setNames(
+    paste0("evaluation-", seq_len(nrow(used_metadata))),
+    used_groups
+  )
+  series_ids <- stats::setNames(
+    paste0("series-", seq_len(nrow(used_metadata))),
+    used_groups
+  )
+
+  evaluations <- lapply(seq_len(nrow(used_metadata)), function(i) {
+    metadata <- used_metadata[i, , drop = FALSE]
+    evaluation <- list(
+      id = unname(evaluation_ids[[as.character(metadata$evaluation)]]),
+      population = as.character(metadata$population)
+    )
+    if (!is.na(metadata$model) && nzchar(metadata$model)) {
+      evaluation$model <- as.character(metadata$model)
+    }
+    evaluation
+  })
+
+  series <- lapply(seq_len(nrow(used_metadata)), function(i) {
+    metadata <- used_metadata[i, , drop = FALSE]
+    group <- as.character(metadata$evaluation)
+    if (!is.na(metadata$model) && nzchar(metadata$model)) {
+      display_value <- as.character(metadata$model)
+      display_role <- "model"
+    } else {
+      display_value <- as.character(metadata$population)
+      display_role <- "population"
+    }
+
+    list(
+      id = unname(series_ids[[group]]),
+      evaluationId = unname(evaluation_ids[[group]]),
+      display = list(
+        label = display_value,
+        group = display_value,
+        role = display_role
+      )
+    )
+  })
+
+  data <- lapply(seq_len(nrow(performance_data)), function(i) {
+    group <- compatibility_group[[i]]
+    list(
+      seriesId = unname(series_ids[[group]]),
+      cutoff = as.numeric(performance_data$probability_threshold[[i]]),
+      sensitivity = as.numeric(performance_data$sensitivity[[i]]),
+      specificity = as.numeric(performance_data$specificity[[i]])
+    )
+  })
+
+  list(
+    schemaVersion = "2.0",
+    type = "roc",
+    evaluations = evaluations,
+    series = series,
+    data = data,
+    x = "false_positive_rate",
+    y = "sensitivity",
+    xAxis = list(label = "1 - Specificity", domain = c(0, 1)),
+    yAxis = list(label = "Sensitivity", domain = c(0, 1)),
+    references = list(list(type = "identity", scope = "global"))
+  )
+}
+
+roc_v2_compatibility_group <- function(
+  performance_data,
+  evaluation_metadata
+) {
+  model_known <- !is.na(evaluation_metadata$model) &
+    nzchar(evaluation_metadata$model)
+
+  if (all(model_known) && "model" %in% names(performance_data)) {
+    return(as.character(performance_data$model))
+  }
+
+  if (all(!model_known) && "population" %in% names(performance_data)) {
+    return(as.character(performance_data$population))
+  }
+
+  if (nrow(evaluation_metadata) == 1L) {
+    return(rep(
+      as.character(evaluation_metadata$evaluation[[1]]),
+      nrow(performance_data)
+    ))
+  }
+
+  stop(
+    paste0(
+      "ROC performance data cannot be joined to semantic evaluation metadata ",
+      "without an explicit compatibility grouping column"
+    ),
+    call. = FALSE
+  )
+}

--- a/R/rtichoke_viz_v2.R
+++ b/R/rtichoke_viz_v2.R
@@ -39,7 +39,10 @@ rtichoke_viz_roc_v2_spec <- function(
   }
 
   if (nrow(evaluation_metadata) == 0L) {
-    stop("ROC evaluation metadata must contain at least one evaluation", call. = FALSE)
+    stop(
+      "ROC evaluation metadata must contain at least one evaluation",
+      call. = FALSE
+    )
   }
 
   compatibility_group <- roc_v2_compatibility_group(

--- a/tests/testthat/test-rtichoke-viz-v2.R
+++ b/tests/testthat/test-rtichoke-viz-v2.R
@@ -92,7 +92,11 @@ test_that("ROC v2 preserves unknown model identity for keyed populations", {
       list(id = "evaluation-2", population = "Population B")
     )
   )
-  expect_false(any(vapply(spec$evaluations, function(x) "model" %in% names(x), logical(1))))
+  expect_false(any(vapply(
+    spec$evaluations,
+    function(x) "model" %in% names(x),
+    logical(1)
+  )))
   expect_identical(
     lapply(spec$series, `[[`, "display"),
     list(

--- a/tests/testthat/test-rtichoke-viz-v2.R
+++ b/tests/testthat/test-rtichoke-viz-v2.R
@@ -1,0 +1,138 @@
+test_that("ROC v2 represents one model in one population", {
+  probs <- list("Model A" = c(0.05, 0.2, 0.7, 0.95))
+  reals <- list("Population A" = c(0, 0, 1, 1))
+
+  spec <- rtichoke:::rtichoke_viz_roc_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  expect_identical(spec$schemaVersion, "2.0")
+  expect_identical(spec$type, "roc")
+  expect_identical(
+    spec$evaluations,
+    list(list(
+      id = "evaluation-1",
+      population = "Population A",
+      model = "Model A"
+    ))
+  )
+  expect_identical(
+    spec$series,
+    list(list(
+      id = "series-1",
+      evaluationId = "evaluation-1",
+      display = list(
+        label = "Model A",
+        group = "Model A",
+        role = "model"
+      )
+    ))
+  )
+  expect_identical(unique(vapply(spec$data, `[[`, "", "seriesId")), "series-1")
+  expect_identical(
+    spec$references,
+    list(list(type = "identity", scope = "global"))
+  )
+})
+
+test_that("ROC v2 keeps multiple models in one shared population distinct", {
+  probs <- list(
+    "Model A" = c(0.05, 0.2, 0.7, 0.95),
+    "Model B" = c(0.1, 0.4, 0.6, 0.9)
+  )
+  reals <- list("Population A" = c(0, 0, 1, 1))
+
+  spec <- rtichoke:::rtichoke_viz_roc_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  expect_identical(
+    vapply(spec$evaluations, `[[`, "", "id"),
+    c("evaluation-1", "evaluation-2")
+  )
+  expect_identical(
+    vapply(spec$evaluations, `[[`, "", "population"),
+    c("Population A", "Population A")
+  )
+  expect_identical(
+    vapply(spec$evaluations, `[[`, "", "model"),
+    c("Model A", "Model B")
+  )
+  expect_identical(
+    vapply(spec$series, `[[`, "", "id"),
+    c("series-1", "series-2")
+  )
+  expect_setequal(
+    vapply(spec$data, `[[`, "", "seriesId"),
+    c("series-1", "series-2")
+  )
+})
+
+test_that("ROC v2 preserves unknown model identity for keyed populations", {
+  probs <- list(
+    "Population A" = c(0.05, 0.2, 0.7, 0.95),
+    "Population B" = c(0.1, 0.4, 0.6, 0.9)
+  )
+  reals <- list(
+    "Population A" = c(0, 0, 1, 1),
+    "Population B" = c(0, 1, 0, 1)
+  )
+
+  spec <- rtichoke:::rtichoke_viz_roc_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  expect_identical(
+    spec$evaluations,
+    list(
+      list(id = "evaluation-1", population = "Population A"),
+      list(id = "evaluation-2", population = "Population B")
+    )
+  )
+  expect_false(any(vapply(spec$evaluations, function(x) "model" %in% names(x), logical(1))))
+  expect_identical(
+    lapply(spec$series, `[[`, "display"),
+    list(
+      list(label = "Population A", group = "Population A", role = "population"),
+      list(label = "Population B", group = "Population B", role = "population")
+    )
+  )
+  expect_setequal(
+    vapply(spec$data, `[[`, "", "seriesId"),
+    c("series-1", "series-2")
+  )
+})
+
+test_that("ROC v2 IDs do not encode compatibility group labels", {
+  probs <- list(
+    "Population A" = c(0.05, 0.2, 0.7, 0.95),
+    "Population B" = c(0.1, 0.4, 0.6, 0.9)
+  )
+  reals <- list(
+    "Population A" = c(0, 0, 1, 1),
+    "Population B" = c(0, 1, 0, 1)
+  )
+  spec <- rtichoke:::rtichoke_viz_roc_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  renamed_probs <- stats::setNames(probs, c("Cohort X", "Cohort Y"))
+  renamed_reals <- stats::setNames(reals, c("Cohort X", "Cohort Y"))
+  renamed_spec <- rtichoke:::rtichoke_viz_roc_v2_spec(
+    prepare_performance_data(renamed_probs, renamed_reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(renamed_probs, renamed_reals)
+  )
+
+  expect_identical(
+    vapply(spec$evaluations, `[[`, "", "id"),
+    vapply(renamed_spec$evaluations, `[[`, "", "id")
+  )
+  expect_identical(
+    vapply(spec$series, `[[`, "", "id"),
+    vapply(renamed_spec$series, `[[`, "", "id")
+  )
+})


### PR DESCRIPTION
## Goal

Add the first internal-only canonical `rtichoke_viz` v2 builder for ROC without switching production rendering away from the current v1 paths.

## Boundary

The builder consumes:

`existing prepare_performance_data() calculations -> build_evaluation_metadata() -> canonical ROC-v2 spec`

No statistical quantity is recomputed in the visualization layer.

## Semantics

- existing `model`/`population` grouping columns are used only as compatibility join keys, with their meaning determined by explicit semantic evaluation metadata;
- shared-outcome inputs preserve model identities and one shared population;
- keyed populations preserve distinct population identities while model identity remains unknown;
- evaluation IDs and series IDs are deterministic ordinals (`evaluation-1`, `series-1`, …) ordered by semantic metadata and do not encode compatibility labels;
- `seriesId` is the geometric identity;
- display label/group/role are derived in the spec layer;
- ROC random-guess identity is emitted as a global reference.

This matches the deterministic-ID convention being characterized independently in the Python adoption work while keeping the implementation native to R lists/helpers.

## Tests

Characterization coverage includes:

- one model × one population;
- multiple models × shared population;
- keyed/multiple populations with unknown model identity;
- renamed compatibility labels retaining the same deterministic evaluation/series ID convention.

## Scope

- internal-only builder;
- no public API changes;
- no production rendering switch;
- no statistical changes;
- no changes to `prepare_performance_data()` output structure;
- no vendored-asset changes in this PR.

## Dependency

`rtichoke_viz v0.2.0` vendoring/provenance landed in #178. This PR now targets `main` directly.