### PR TITLE
Show logo in generated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-# rtichoke
+# rtichoke <a href="https://uriahf.github.io/rtichoke/"><img src="man/figures/logo.png" align="right" height="160" /></a>
 
 <!-- badges: start -->
 


### PR DESCRIPTION
Keeps the generated README.md in sync with README.Rmd by adding the existing rtichoke logo to the heading. This is intentionally a one-line generated-file fix; no README content or other files are changed.