### PR TITLE
Fix package branding assets

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: ~
+url: https://uriahf.github.io/rtichoke/
 template:
   bootstrap: 5
 


### PR DESCRIPTION
## Summary
- rebuild the branding work directly on current `main`, including the corrected logo uploaded in commit 5c44cb7
- set the canonical pkgdown site URL
- keep README content and existing logo markup unchanged for now

## Why this replaces #188
The previous branch had diverged before the corrected logo was uploaded to `main`. This branch now starts from the corrected `main` state, avoiding stale/broken binary history.

## Next verification
Use the pkgdown preview to verify homepage logo behavior, then add favicon assets from the canonical logo if still needed.