### PR TITLE
Update Codecov action to v7

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -62,7 +62,7 @@ jobs:
           covr::to_cobertura(cov)
         shell: Rscript {0}
 
-      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
           files: ./cobertura.xml


### PR DESCRIPTION
## Summary

- update the pinned Codecov Action from v6.0.0 to v7.0.0
- retain immutable full-SHA pinning
- keep CLI signature verification enabled

This release addresses Codecov's Keybase/GPG key migration, which caused the post-merge coverage upload to fail repeatedly with `Can't check signature: No public key`.

## Validation

- workflow diff is limited to the Codecov Action SHA/version comment
- `git diff --check` passes