### PR TITLE
Authenticate Codecov uploads with OIDC

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -25,7 +25,9 @@ on:
 
 name: test-coverage
 
-permissions: read-all
+permissions:
+  contents: read
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -64,11 +66,11 @@ jobs:
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
+          use_oidc: true
           fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
           files: ./cobertura.xml
           plugins: noop
           disable_search: true
-          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()


### PR DESCRIPTION
## Summary

- grant the coverage workflow `id-token: write` with `contents: read`
- authenticate Codecov uploads using short-lived GitHub OIDC credentials
- remove the empty `CODECOV_TOKEN` input

This fixes protected-branch uploads failing on `main` with `Token required because branch is protected` without adding a long-lived repository secret.

## Validation

- workflow diff is limited to Codecov authentication and required permissions
- `git diff --check` passes