### PR TITLE
Optimize CI workflows for faster PR feedback

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,5 +1,10 @@
 on:
   pull_request:
+    paths:
+      - '**.R'
+      - '**.Rmd'
+      - 'air.toml'
+      - '.github/workflows/style.yaml'
 
 name: style
 

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -41,6 +41,8 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
Optimized the CI/CD pipeline to improve feedback loop speeds:
- Added `use-public-rspm: true` to `setup-r@v2` step in `test-coverage.yaml` and `documentation.yaml` to leverage pre-built R package binaries on Linux runners instead of building from source.
- Added targeted `paths` filtering to `style.yaml` so formatting checks are skipped on PRs that do not alter R code, Rmd files, or formatting config.

---
*PR created automatically by Jules for task [15288797436654633556](https://jules.google.com/task/15288797436654633556) started by @uriahf*