### PR TITLE
Pin Air formatting in pre-commit and CI

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -24,6 +24,8 @@ jobs:
           fetch-depth: 0
 
       - uses: posit-dev/setup-air@v1
+        with:
+          version: "0.11.0"
 
       - name: Find changed R files
         id: changed-r-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,14 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
+  - repo: https://github.com/posit-dev/air-pre-commit
+    rev: 0.11.0
+    hooks:
+      - id: air-format
+
   - repo: https://github.com/lorenzwalthert/precommit
     rev: v0.4.3.9003
     hooks:
-      - id: style-files
-        name: Style R files
       - id: roxygenize
         name: Regenerate documentation
       - id: use-tidy-description

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+Install the development dependencies for the R package, then enable the
+repository's pre-commit hooks:
+
+```sh
+python -m pip install pre-commit
+pre-commit install
+```
+
+The hook formats staged R files with Air before each commit. Its Air version is
+pinned to the same version used by GitHub Actions. To check every tracked file
+without committing, run:
+
+```sh
+pre-commit run --all-files
+```


### PR DESCRIPTION
## Summary

- replace the existing `style-files` pre-commit hook with the official Air hook pinned to 0.11.0
- pin the GitHub Actions style job to the same Air version
- document installing and running the existing pre-commit workflow
- preserve the repository's YAML/JSON/whitespace, roxygen, and DESCRIPTION hooks

## Verification

- `pre-commit validate-config`
- `pre-commit run air-format --files R/rtichoke_viz_v2.R`
- `git diff --check`

A full historical `--all-files` run identified existing Air drift in `data-raw/example_dat.R` and `inst/combined_decision_curve_new.R`; those unrelated rewrites are intentionally excluded from this tooling-only PR.