### PR TITLE
Restore Naming Conventions guide to pkgdown navigation

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -24,6 +24,8 @@ navbar:
         - text: "Performance Tables"
           href: articles/performance-tables.html
         - text: "-------------------"
+        - text: "Naming Conventions"
+          href: articles/naming_convention.html
         - text: "Recipes & Workflows"
           href: articles/recipes-and-workflows.html
     recipes:

--- a/vignettes/naming_convention.Rmd
+++ b/vignettes/naming_convention.Rmd
@@ -1,8 +1,8 @@
 ---
-title: "Naming Convention"
+title: "Naming Conventions"
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Naming Convention}
+  %\VignetteIndexEntry{Naming Conventions}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -18,11 +18,18 @@ knitr::opts_chunk$set(
 library(rtichoke)
 ```
 
+## Naming conventions
 
-### Naming Convention
+rtichoke uses a consistent naming pattern to distinguish high-level workflows
+from lower-level plotting and rendering functions. Functions named `create_*()`
+start from predictions and outcomes and create a curve, table, or report.
+`prepare_performance_data()` exposes the common performance-data layer, while
+`plot_*()` and `render_*()` functions operate on already prepared performance
+data where those lower-level interfaces are available.
+
+The table below summarizes the main entry points.
 
 ```{r echo=FALSE}
-
 tibble::tribble(
   ~"Output", ~"Predictions and Outcomes", ~"Performance Data",
   "Performance Data", "`prepare_performance_data()`", "",
@@ -54,7 +61,10 @@ tibble::tribble(
   )
 ```
 
-### Curves based on Performance Metrics
+## Curves and performance metrics
+
+The performance curves are different views of the same underlying performance
+data. This table shows which quantities define the axes of each curve.
 
 ```{r echo=FALSE}
 tibble::tribble(
@@ -66,10 +76,6 @@ tibble::tribble(
   "Decision", " ", " ", " ", " ", " ", "y", "x"
 ) |>
   gt::gt(rowname_col = "Curve") |>
-  #
-  # gt::fmt_markdown(columns = c("Sens", "Spec", "PPV", "PPCR", "Lift", "NB", "P. Thr")) |>
-  #
-  # gt::fmt_markdown(columns = everything()) |>
   gt::tab_style(
     style = list(
       gt::cell_text(weight = "bold")


### PR DESCRIPTION
## Summary

- restore the existing Naming Conventions vignette to the visible pkgdown Guides menu
- keep the documentation structure introduced in #197 intact
- clarify the vignette's API mental model without changing its two core reference tables
- rename the page title from singular "Naming Convention" to "Naming Conventions"

## Why

PR #197 retained `vignettes/naming_convention.Rmd` and still listed it under `articles.contents`, but the new hand-written Guides navbar omitted it. As a result, the article continued to build but became effectively undiscoverable from the site navigation.

This is a small docs-only follow-up that restores discoverability rather than reverting the documentation overhaul.