### PR TITLE
Implement canonical Lift v2 producer in R

### DIFF
--- a/R/lift.R
+++ b/R/lift.R
@@ -103,24 +103,31 @@ create_lift_curve <- function(
     "#D1603D",
     "#585123"
   ),
-  size = NULL
+  size = NULL,
+  renderer = "default"
 ) {
   if (!is.na(chosen_threshold)) {
     check_chosen_threshold_input(chosen_threshold)
   }
 
-  prepare_performance_data(
+  performance_data <- prepare_performance_data(
     probs = probs,
     reals = reals,
     by = by,
     stratified_by = stratified_by
-  ) |>
-    plot_lift_curve(
-      chosen_threshold = chosen_threshold,
-      interactive = interactive,
-      color_values = color_values,
-      size = size
-    )
+  )
+  evaluation_metadata <- if (identical(renderer, "browser")) {
+    build_evaluation_metadata(probs, reals)
+  }
+  plot_lift_curve(
+    performance_data,
+    chosen_threshold = chosen_threshold,
+    interactive = interactive,
+    color_values = color_values,
+    size = size,
+    renderer = renderer,
+    evaluation_metadata = evaluation_metadata
+  )
 }
 
 
@@ -179,8 +186,24 @@ plot_lift_curve <- function(
     "#D1603D",
     "#585123"
   ),
-  size = NULL
+  size = NULL,
+  renderer = "default",
+  evaluation_metadata = NULL
 ) {
+  renderer <- rtichoke_viz_renderer(renderer, interactive)
+  if (renderer == "browser") {
+    if (is.null(evaluation_metadata)) {
+      stop(
+        "Browser rendering requires explicit evaluation_metadata",
+        call. = FALSE
+      )
+    }
+    return(render_rtichoke_viz_browser(rtichoke_viz_lift_v2_spec(
+      performance_data,
+      evaluation_metadata
+    )))
+  }
+
   rtichoke_curve_list <- performance_data |>
     create_rtichoke_curve_list("lift", size = size, color_values = color_values)
 
@@ -200,7 +223,7 @@ plot_lift_curve <- function(
     perf_dat_type
   )
 
-  if (interactive == FALSE) {
+  if (renderer == "ggplot2") {
     reference_lines <- create_reference_lines_data_frame("lift")
 
     lift_curve <- performance_data |>
@@ -211,7 +234,7 @@ plot_lift_curve <- function(
       ggplot2::ylab("Lift")
   }
 
-  if (interactive == TRUE) {
+  if (renderer == "plotly") {
     lift_curve <- rtichoke_curve_list |>
       create_plotly_curve()
   }

--- a/R/rtichoke_viz_v2.R
+++ b/R/rtichoke_viz_v2.R
@@ -45,7 +45,7 @@ render_rtichoke_viz_browser <- function(spec) {
     roc = "renderRocV2",
     gains = "renderGainsV2"
   )
-  renderer <- unname(renderers[[spec$type]])
+  renderer <- if (spec$type %in% names(renderers)) unname(renderers[[spec$type]]) else NULL
   if (is.null(renderer)) {
     stop(
       "Browser rendering is not available for chart type: ",
@@ -92,6 +92,81 @@ render_rtichoke_viz_browser <- function(spec) {
   ))
 }
 
+#' Build a canonical rtichoke_viz v2 lift specification
+#'
+#' Translate already-computed lift performance data plus explicit semantic
+#' evaluation metadata into the canonical rtichoke_viz v2 contract. Perfect
+#' model reference geometry is derived from the same production prevalence
+#' values used by the existing lift renderer. This helper is deliberately
+#' internal and is not wired into production rendering yet.
+#'
+#' @inheritParams rtichoke_viz_roc_v2_spec
+#'
+#' @return A nested list representing a canonical lift v2 specification.
+#' @noRd
+rtichoke_viz_lift_v2_spec <- function(
+  performance_data,
+  evaluation_metadata
+) {
+  spec <- rtichoke_viz_curve_v2_spec(
+    performance_data,
+    evaluation_metadata,
+    type = "lift"
+  )
+
+  populations <- unique(vapply(
+    spec$evaluations,
+    `[[`,
+    character(1),
+    "population"
+  ))
+  prevalence <- v2_population_prevalence(
+    performance_data,
+    evaluation_metadata,
+    populations
+  )
+
+  perfect_references <- lapply(populations, function(population) {
+    p <- as.numeric(prevalence[[population]])
+    inv_p <- 1 / p
+    list(
+      type = "path",
+      scope = "population",
+      population = population,
+      label = "Perfect Model",
+      points = list(
+        list(x = 0, y = inv_p),
+        list(x = p, y = inv_p),
+        list(x = 1, y = 1)
+      )
+    )
+  })
+
+  spec$references <- c(
+    list(list(
+      type = "horizontal",
+      value = 1,
+      scope = "global",
+      label = "Random"
+    )),
+    perfect_references
+  )
+
+  data_lifts <- vapply(spec$data, `[[`, numeric(1), "lift")
+  perfect_lifts <- vapply(populations, function(pop) {
+    1 / as.numeric(prevalence[[pop]])
+  }, numeric(1))
+
+  max_lift <- max(c(data_lifts, perfect_lifts, 1), na.rm = TRUE)
+
+  spec$yAxis <- list(
+    label = "Lift",
+    domain = c(0, max_lift)
+  )
+
+  spec
+}
+
 #' Build a canonical rtichoke_viz v2 gains specification
 #'
 #' Translate already-computed gains performance data plus explicit semantic
@@ -120,7 +195,7 @@ rtichoke_viz_gains_v2_spec <- function(
     character(1),
     "population"
   ))
-  prevalence <- gains_v2_population_prevalence(
+  prevalence <- v2_population_prevalence(
     performance_data,
     evaluation_metadata,
     populations
@@ -148,7 +223,7 @@ rtichoke_viz_gains_v2_spec <- function(
   spec
 }
 
-gains_v2_population_prevalence <- function(
+v2_population_prevalence <- function(
   performance_data,
   evaluation_metadata,
   populations
@@ -167,7 +242,7 @@ gains_v2_population_prevalence <- function(
         values <- unique(unname(prevalence[names(prevalence) %in% models]))
         if (length(values) != 1L) {
           stop(
-            "Gains performance data must have one prevalence per population: ",
+            "Performance data must have one prevalence per population: ",
             population,
             call. = FALSE
           )
@@ -186,7 +261,7 @@ gains_v2_population_prevalence <- function(
   missing_populations <- setdiff(populations, names(prevalence))
   if (length(missing_populations) > 0L) {
     stop(
-      "Gains performance data is missing prevalence for populations: ",
+      "Performance data is missing prevalence for populations: ",
       paste(missing_populations, collapse = ", "),
       call. = FALSE
     )
@@ -195,16 +270,19 @@ gains_v2_population_prevalence <- function(
   prevalence[populations]
 }
 
+gains_v2_population_prevalence <- v2_population_prevalence
+
 rtichoke_viz_curve_v2_spec <- function(
   performance_data,
   evaluation_metadata,
-  type = c("roc", "gains")
+  type = c("roc", "gains", "lift")
 ) {
   type <- match.arg(type)
   required_columns <- switch(
     type,
     roc = c("probability_threshold", "sensitivity", "specificity"),
-    gains = c("probability_threshold", "ppcr", "sensitivity")
+    gains = c("probability_threshold", "ppcr", "sensitivity"),
+    lift = c("probability_threshold", "ppcr", "lift")
   )
   missing_columns <- setdiff(required_columns, names(performance_data))
   if (length(missing_columns) > 0L) {
@@ -307,13 +385,17 @@ rtichoke_viz_curve_v2_spec <- function(
     group <- compatibility_group[[i]]
     datum <- list(
       seriesId = unname(series_ids[[group]]),
-      cutoff = as.numeric(performance_data$probability_threshold[[i]]),
-      sensitivity = as.numeric(performance_data$sensitivity[[i]])
+      cutoff = as.numeric(performance_data$probability_threshold[[i]])
     )
     if (type == "roc") {
+      datum$sensitivity <- as.numeric(performance_data$sensitivity[[i]])
       datum$specificity <- as.numeric(performance_data$specificity[[i]])
-    } else {
+    } else if (type == "gains") {
+      datum$sensitivity <- as.numeric(performance_data$sensitivity[[i]])
       datum$ppcr <- as.numeric(performance_data$ppcr[[i]])
+    } else if (type == "lift") {
+      datum$ppcr <- as.numeric(performance_data$ppcr[[i]])
+      datum$lift <- as.numeric(performance_data$lift[[i]])
     }
     datum
   })
@@ -333,16 +415,31 @@ rtichoke_viz_curve_v2_spec <- function(
     ))
   }
 
+  if (type == "gains") {
+    return(list(
+      schemaVersion = "2.0",
+      type = "gains",
+      evaluations = evaluations,
+      series = series,
+      data = data,
+      x = "ppcr",
+      y = "sensitivity",
+      xAxis = list(label = "Predicted Positives (Rate)", domain = c(0, 1)),
+      yAxis = list(label = "Sensitivity", domain = c(0, 1)),
+      references = list()
+    ))
+  }
+
   list(
     schemaVersion = "2.0",
-    type = "gains",
+    type = "lift",
     evaluations = evaluations,
     series = series,
     data = data,
     x = "ppcr",
-    y = "sensitivity",
+    y = "lift",
     xAxis = list(label = "Predicted Positives (Rate)", domain = c(0, 1)),
-    yAxis = list(label = "Sensitivity", domain = c(0, 1)),
+    yAxis = list(label = "Lift"),
     references = list()
   )
 }

--- a/R/rtichoke_viz_v2.R
+++ b/R/rtichoke_viz_v2.R
@@ -45,7 +45,11 @@ render_rtichoke_viz_browser <- function(spec) {
     roc = "renderRocV2",
     gains = "renderGainsV2"
   )
-  renderer <- if (spec$type %in% names(renderers)) unname(renderers[[spec$type]]) else NULL
+  renderer <- if (spec$type %in% names(renderers)) {
+    unname(renderers[[spec$type]])
+  } else {
+    NULL
+  }
   if (is.null(renderer)) {
     stop(
       "Browser rendering is not available for chart type: ",
@@ -153,9 +157,13 @@ rtichoke_viz_lift_v2_spec <- function(
   )
 
   data_lifts <- vapply(spec$data, `[[`, numeric(1), "lift")
-  perfect_lifts <- vapply(populations, function(pop) {
-    1 / as.numeric(prevalence[[pop]])
-  }, numeric(1))
+  perfect_lifts <- vapply(
+    populations,
+    function(pop) {
+      1 / as.numeric(prevalence[[pop]])
+    },
+    numeric(1)
+  )
 
   max_lift <- max(c(data_lifts, perfect_lifts, 1), na.rm = TRUE)
 

--- a/man/create_lift_curve.Rd
+++ b/man/create_lift_curve.Rd
@@ -14,7 +14,8 @@ create_lift_curve(
   color_values = c("#1b9e77", "#d95f02", "#7570b3", "#e7298a", "#07004D", "#E6AB02",
     "#FE5F55", "#54494B", "#006E90", "#BC96E6", "#52050A", "#1F271B", "#BE7C4D",
     "#63768D", "#08A045", "#320A28", "#82FF9E", "#2176FF", "#D1603D", "#585123"),
-  size = NULL
+  size = NULL,
+  renderer = "default"
 )
 }
 \arguments{
@@ -36,6 +37,10 @@ plots}
 \item{color_values}{color palette}
 
 \item{size}{the size of the curve}
+
+\item{renderer}{rendering backend. \code{"default"} preserves the existing
+\code{interactive} behavior; alternatives are \code{"ggplot2"}, \code{"plotly"}, and
+\code{"browser"}.}
 }
 \description{
 Create a Lift Curve

--- a/man/plot_lift_curve.Rd
+++ b/man/plot_lift_curve.Rd
@@ -11,7 +11,9 @@ plot_lift_curve(
   color_values = c("#1b9e77", "#d95f02", "#7570b3", "#e7298a", "#07004D", "#E6AB02",
     "#FE5F55", "#54494B", "#006E90", "#BC96E6", "#52050A", "#1F271B", "#BE7C4D",
     "#63768D", "#08A045", "#320A28", "#82FF9E", "#2176FF", "#D1603D", "#585123"),
-  size = NULL
+  size = NULL,
+  renderer = "default",
+  evaluation_metadata = NULL
 )
 }
 \arguments{
@@ -25,6 +27,14 @@ plots}
 \item{color_values}{color palette}
 
 \item{size}{the size of the curve}
+
+\item{renderer}{rendering backend. \code{"default"} preserves the existing
+\code{interactive} behavior; alternatives are \code{"ggplot2"}, \code{"plotly"}, and
+\code{"browser"}.}
+
+\item{evaluation_metadata}{explicit semantic evaluation metadata required
+when \code{renderer = "browser"}. It is supplied automatically by
+\code{\link[=create_roc_curve]{create_roc_curve()}}.}
 }
 \description{
 Plot a LIFT Curve

--- a/tests/testthat/test-rtichoke-viz-v2.R
+++ b/tests/testthat/test-rtichoke-viz-v2.R
@@ -280,3 +280,209 @@ test_that("gains browser renderer consumes the canonical v2 builder", {
   expect_match(as.character(browser), "renderGainsV2", fixed = TRUE)
   expect_match(as.character(browser), '"schemaVersion":"2.0"', fixed = TRUE)
 })
+
+test_that("Lift v2 represents one model in one population", {
+  probs <- list("Model A" = c(0.05, 0.2, 0.7, 0.95))
+  reals <- list("Population A" = c(0, 0, 0, 1))
+  perf_dat <- prepare_performance_data(probs, reals, by = 0.25)
+  meta <- rtichoke:::build_evaluation_metadata(probs, reals)
+
+  spec <- rtichoke:::rtichoke_viz_lift_v2_spec(perf_dat, meta)
+
+  expect_identical(spec$schemaVersion, "2.0")
+  expect_identical(spec$type, "lift")
+  expect_identical(spec$x, "ppcr")
+  expect_identical(spec$y, "lift")
+
+  expect_identical(
+    spec$evaluations,
+    list(list(
+      id = "evaluation-1",
+      population = "Population A",
+      model = "Model A"
+    ))
+  )
+
+  expect_identical(
+    spec$series,
+    list(list(
+      id = "series-1",
+      evaluationId = "evaluation-1",
+      display = list(
+        label = "Model A",
+        group = "Model A",
+        role = "model"
+      )
+    ))
+  )
+
+  expect_identical(unique(vapply(spec$data, `[[`, "", "seriesId")), "series-1")
+  expect_true(all(c("seriesId", "cutoff", "ppcr", "lift") %in% names(spec$data[[1]])))
+
+  expect_identical(
+    spec$references[[1]],
+    list(
+      type = "horizontal",
+      value = 1,
+      scope = "global",
+      label = "Random"
+    )
+  )
+
+  prevalence <- unname(rtichoke:::get_prevalence_from_performance_data(perf_dat))
+  expect_identical(spec$references[[2]]$scope, "population")
+  expect_identical(spec$references[[2]]$population, "Population A")
+  expect_identical(spec$references[[2]]$label, "Perfect Model")
+  expect_identical(
+    spec$references[[2]]$points,
+    list(
+      list(x = 0, y = 1 / prevalence),
+      list(x = prevalence, y = 1 / prevalence),
+      list(x = 1, y = 1)
+    )
+  )
+
+  expect_identical(spec$xAxis, list(label = "Predicted Positives (Rate)", domain = c(0, 1)))
+  expect_identical(spec$yAxis$label, "Lift")
+  expect_equal(spec$yAxis$domain[[1]], 0)
+  expect_true(spec$yAxis$domain[[2]] >= 1 / prevalence)
+})
+
+test_that("Lift v2 shares one perfect path across two models in one shared population", {
+  probs <- list(
+    "Model A" = c(0.05, 0.2, 0.7, 0.95),
+    "Model B" = c(0.1, 0.4, 0.6, 0.9)
+  )
+  reals <- list("Population A" = c(0, 0, 1, 1))
+
+  spec <- rtichoke:::rtichoke_viz_lift_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  expect_length(spec$evaluations, 2)
+  expect_length(spec$series, 2)
+  expect_length(spec$references, 2)
+  expect_identical(spec$references[[1]]$label, "Random")
+  expect_identical(spec$references[[2]]$label, "Perfect Model")
+  expect_identical(spec$references[[2]]$population, "Population A")
+  expect_setequal(
+    vapply(spec$data, `[[`, "", "seriesId"),
+    c("series-1", "series-2")
+  )
+})
+
+test_that("Lift v2 keeps distinct population-owned references for multiple populations", {
+  probs <- list(
+    "Population A" = c(0.05, 0.2, 0.7, 0.95),
+    "Population B" = c(0.1, 0.4, 0.6, 0.9)
+  )
+  reals <- list(
+    "Population A" = c(0, 0, 0, 1),
+    "Population B" = c(0, 0, 1, 1)
+  )
+
+  spec <- rtichoke:::rtichoke_viz_lift_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  perfect_refs <- spec$references[-1]
+  expect_length(perfect_refs, 2)
+  expect_identical(
+    vapply(perfect_refs, `[[`, "", "population"),
+    c("Population A", "Population B")
+  )
+  expect_false(identical(perfect_refs[[1]]$points, perfect_refs[[2]]$points))
+})
+
+test_that("Lift v2 keeps equal-prevalence distinct populations as separate reference owners", {
+  probs <- list(
+    "Population A" = c(0.05, 0.2, 0.7, 0.95),
+    "Population B" = c(0.1, 0.4, 0.6, 0.9)
+  )
+  reals <- list(
+    "Population A" = c(0, 0, 1, 1),
+    "Population B" = c(0, 1, 0, 1)
+  )
+
+  spec <- rtichoke:::rtichoke_viz_lift_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  perfect_refs <- spec$references[-1]
+  expect_length(perfect_refs, 2)
+  expect_identical(
+    vapply(perfect_refs, `[[`, "", "population"),
+    c("Population A", "Population B")
+  )
+  expect_identical(perfect_refs[[1]]$points, perfect_refs[[2]]$points)
+})
+
+test_that("Lift v2 generates deterministic evaluation and series IDs independent of group names", {
+  probs <- list(
+    "Population A" = c(0.05, 0.2, 0.7, 0.95),
+    "Population B" = c(0.1, 0.4, 0.6, 0.9)
+  )
+  reals <- list(
+    "Population A" = c(0, 0, 1, 1),
+    "Population B" = c(0, 1, 0, 1)
+  )
+  spec1 <- rtichoke:::rtichoke_viz_lift_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  renamed_probs <- stats::setNames(probs, c("Group X", "Group Y"))
+  renamed_reals <- stats::setNames(reals, c("Group X", "Group Y"))
+  spec2 <- rtichoke:::rtichoke_viz_lift_v2_spec(
+    prepare_performance_data(renamed_probs, renamed_reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(renamed_probs, renamed_reals)
+  )
+
+  expect_identical(
+    vapply(spec1$evaluations, `[[`, "", "id"),
+    vapply(spec2$evaluations, `[[`, "", "id")
+  )
+  expect_identical(
+    vapply(spec1$series, `[[`, "", "id"),
+    vapply(spec2$series, `[[`, "", "id")
+  )
+})
+
+test_that("Lift v2 preserves unknown model semantics when model is unknown", {
+  probs <- list(
+    "Population A" = c(0.05, 0.2, 0.7, 0.95),
+    "Population B" = c(0.1, 0.4, 0.6, 0.9)
+  )
+  reals <- list(
+    "Population A" = c(0, 0, 1, 1),
+    "Population B" = c(0, 1, 0, 1)
+  )
+
+  spec <- rtichoke:::rtichoke_viz_lift_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  expect_false("model" %in% names(spec$evaluations[[1]]))
+  expect_identical(spec$series[[1]]$display$role, "population")
+  expect_identical(spec$series[[1]]$display$label, "Population A")
+})
+
+test_that("Lift default public Plotly behavior remains unchanged and browser Lift fails clearly", {
+  probs <- list("Model A" = c(0.05, 0.2, 0.7, 0.95))
+  reals <- list("Population A" = c(0, 0, 1, 1))
+
+  plotly_plot <- create_lift_curve(probs, reals, by = 0.25)
+  expect_s3_class(plotly_plot, "plotly")
+
+  ggplot_plot <- create_lift_curve(probs, reals, by = 0.25, interactive = FALSE)
+  expect_s3_class(ggplot_plot, "ggplot")
+
+  expect_error(
+    create_lift_curve(probs, reals, by = 0.25, renderer = "browser"),
+    "Browser rendering is not available for chart type: lift"
+  )
+})

--- a/tests/testthat/test-rtichoke-viz-v2.R
+++ b/tests/testthat/test-rtichoke-viz-v2.R
@@ -317,7 +317,9 @@ test_that("Lift v2 represents one model in one population", {
   )
 
   expect_identical(unique(vapply(spec$data, `[[`, "", "seriesId")), "series-1")
-  expect_true(all(c("seriesId", "cutoff", "ppcr", "lift") %in% names(spec$data[[1]])))
+  expect_true(all(
+    c("seriesId", "cutoff", "ppcr", "lift") %in% names(spec$data[[1]])
+  ))
 
   expect_identical(
     spec$references[[1]],
@@ -329,7 +331,9 @@ test_that("Lift v2 represents one model in one population", {
     )
   )
 
-  prevalence <- unname(rtichoke:::get_prevalence_from_performance_data(perf_dat))
+  prevalence <- unname(rtichoke:::get_prevalence_from_performance_data(
+    perf_dat
+  ))
   expect_identical(spec$references[[2]]$scope, "population")
   expect_identical(spec$references[[2]]$population, "Population A")
   expect_identical(spec$references[[2]]$label, "Perfect Model")
@@ -342,7 +346,10 @@ test_that("Lift v2 represents one model in one population", {
     )
   )
 
-  expect_identical(spec$xAxis, list(label = "Predicted Positives (Rate)", domain = c(0, 1)))
+  expect_identical(
+    spec$xAxis,
+    list(label = "Predicted Positives (Rate)", domain = c(0, 1))
+  )
   expect_identical(spec$yAxis$label, "Lift")
   expect_equal(spec$yAxis$domain[[1]], 0)
   expect_true(spec$yAxis$domain[[2]] >= 1 / prevalence)


### PR DESCRIPTION
Implements the canonical static Lift v2 producer/builder in R matching rtichoke_viz v2 contract specifications and Python parity.

Key changes and deliverable details:
- **Canonical Lift v2 Builder**: `rtichoke_viz_lift_v2_spec(performance_data, evaluation_metadata)` internal helper created in `R/rtichoke_viz_v2.R`.
- **Prevalence & Geometry Sourcing**: Population prevalence is derived from existing statistical performance layer via generalized `v2_population_prevalence()`. Perfect Prediction points are calculated as `(0, 1/p) -> (p, 1/p) -> (1, 1)`.
- **Evaluation / Series IDs**: Deterministic IDs (`evaluation-1`, `series-1`, etc.) generated via reused `rtichoke_viz_curve_v2_spec()` helper logic.
- **Reference Ownership & Population Disambiguation**: Perfect Prediction paths are owned by population scope (`scope = "population"`). Multiple models in a shared population share 1 Perfect Prediction reference line. Distinct populations retain separate reference objects even when numerically equal in prevalence.
- **Plotly & Browser Gating**: Plotly default rendering behavior (`renderer = "default"`) is unchanged. Browser rendering (`renderer = "browser"`) fails clearly with `"Browser rendering is not available for chart type: lift"` until an immutable `rtichoke_viz` release containing Lift support is vendored.
- **Tests**: Comprehensive unit tests added to `tests/testthat/test-rtichoke-viz-v2.R` and passing.

---
*PR created automatically by Jules for task [7612914896919486986](https://jules.google.com/task/7612914896919486986) started by @uriahf*