### PR TITLE
Add canonical PerformanceTableSpec producer

### DIFF
--- a/R/performance_table_v2.R
+++ b/R/performance_table_v2.R
@@ -97,24 +97,34 @@ rtichoke_viz_performance_table_v2_spec <- function(
     ppcr = "Predicted Positives Condition Rate",
     net_benefit = "Net Benefit"
   )
-  source_metrics <- names(metric_map)[names(metric_map) %in% names(performance_data)]
+  source_metrics <- names(metric_map)[
+    names(metric_map) %in% names(performance_data)
+  ]
   metrics <- lapply(source_metrics, function(source) {
     id <- unname(metric_map[[source]])
     list(id = id, label = unname(metric_labels[[id]]))
   })
 
-  operating_column <- if (stratified_by == "ppcr") "ppcr" else {
+  operating_column <- if (stratified_by == "ppcr") {
+    "ppcr"
+  } else {
     "probability_threshold"
   }
   if (!operating_column %in% names(performance_data)) {
-    stop("Performance data is missing operating-point column: ", operating_column,
+    stop(
+      "Performance data is missing operating-point column: ",
+      operating_column,
       call. = FALSE
     )
   }
 
   canonical_number <- function(value) {
     value <- as.numeric(value)
-    if (length(value) == 0L || is.na(value) || is.nan(value)) NULL else value
+    if (length(value) == 0L || is.na(value) || is.nan(value)) {
+      NULL
+    } else {
+      value
+    }
   }
 
   rows <- lapply(seq_len(nrow(performance_data)), function(i) {

--- a/R/performance_table_v2.R
+++ b/R/performance_table_v2.R
@@ -1,0 +1,145 @@
+#' Build a canonical rtichoke_viz v2 performance-table specification
+#'
+#' Translate already-computed performance data plus explicit semantic
+#' evaluation metadata into the canonical sibling PerformanceTableSpec.
+#' This helper performs presentation normalization only: all statistics come
+#' from `prepare_performance_data()`.
+#'
+#' @param performance_data Output from [prepare_performance_data()].
+#' @param evaluation_metadata Output from [build_evaluation_metadata()].
+#' @param stratified_by Operating-point semantics used to prepare the data.
+#'
+#' @return A nested list representing a canonical PerformanceTableSpec.
+#' @noRd
+rtichoke_viz_performance_table_v2_spec <- function(
+  performance_data,
+  evaluation_metadata,
+  stratified_by = "probability_threshold"
+) {
+  stratified_by <- match.arg(
+    stratified_by,
+    c("probability_threshold", "ppcr")
+  )
+  required_metadata <- c("model", "population", "evaluation")
+  missing_metadata <- setdiff(required_metadata, names(evaluation_metadata))
+  if (length(missing_metadata) > 0L) {
+    stop(
+      "Performance-table evaluation metadata is missing columns: ",
+      paste(missing_metadata, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  compatibility_group <- roc_v2_compatibility_group(
+    performance_data,
+    evaluation_metadata
+  )
+  metadata_group <- as.character(evaluation_metadata$evaluation)
+  missing_groups <- setdiff(unique(compatibility_group), metadata_group)
+  if (length(missing_groups) > 0L) {
+    stop(
+      "Performance rows are missing evaluation metadata: ",
+      paste(missing_groups, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  used_metadata <- evaluation_metadata[
+    evaluation_metadata$evaluation %in% unique(compatibility_group),
+    ,
+    drop = FALSE
+  ]
+  used_groups <- as.character(used_metadata$evaluation)
+  evaluation_ids <- stats::setNames(
+    paste0("evaluation-", seq_len(nrow(used_metadata))),
+    used_groups
+  )
+
+  evaluations <- lapply(seq_len(nrow(used_metadata)), function(i) {
+    metadata <- used_metadata[i, , drop = FALSE]
+    evaluation <- list(
+      id = unname(evaluation_ids[[as.character(metadata$evaluation)]]),
+      population = as.character(metadata$population)
+    )
+    if (!is.na(metadata$model) && nzchar(metadata$model)) {
+      evaluation$model <- as.character(metadata$model)
+    }
+    evaluation
+  })
+
+  metric_map <- c(
+    TP = "true_positives",
+    TN = "true_negatives",
+    FP = "false_positives",
+    FN = "false_negatives",
+    sensitivity = "sensitivity",
+    specificity = "specificity",
+    FPR = "false_positive_rate",
+    PPV = "ppv",
+    NPV = "npv",
+    lift = "lift",
+    predicted_positives = "predicted_positives",
+    ppcr = "ppcr",
+    NB = "net_benefit"
+  )
+  metric_labels <- c(
+    true_positives = "True Positives",
+    true_negatives = "True Negatives",
+    false_positives = "False Positives",
+    false_negatives = "False Negatives",
+    sensitivity = "Sensitivity",
+    specificity = "Specificity",
+    false_positive_rate = "False Positive Rate",
+    ppv = "PPV",
+    npv = "NPV",
+    lift = "Lift",
+    predicted_positives = "Predicted Positives",
+    ppcr = "Predicted Positives Condition Rate",
+    net_benefit = "Net Benefit"
+  )
+  source_metrics <- names(metric_map)[names(metric_map) %in% names(performance_data)]
+  metrics <- lapply(source_metrics, function(source) {
+    id <- unname(metric_map[[source]])
+    list(id = id, label = unname(metric_labels[[id]]))
+  })
+
+  operating_column <- if (stratified_by == "ppcr") "ppcr" else {
+    "probability_threshold"
+  }
+  if (!operating_column %in% names(performance_data)) {
+    stop("Performance data is missing operating-point column: ", operating_column,
+      call. = FALSE
+    )
+  }
+
+  canonical_number <- function(value) {
+    value <- as.numeric(value)
+    if (length(value) == 0L || is.na(value) || is.nan(value)) NULL else value
+  }
+
+  rows <- lapply(seq_len(nrow(performance_data)), function(i) {
+    group <- compatibility_group[[i]]
+    values <- lapply(source_metrics, function(source) {
+      list(
+        metricId = unname(metric_map[[source]]),
+        estimate = canonical_number(performance_data[[source]][[i]])
+      )
+    })
+    list(
+      evaluationId = unname(evaluation_ids[[group]]),
+      operatingPoint = list(
+        type = stratified_by,
+        value = as.numeric(performance_data[[operating_column]][[i]])
+      ),
+      values = values
+    )
+  })
+
+  list(
+    schemaVersion = "2.0",
+    type = "performance_table",
+    evaluations = evaluations,
+    metrics = metrics,
+    rows = rows
+  )
+}

--- a/tests/testthat/test-performance-table-v2.R
+++ b/tests/testthat/test-performance-table-v2.R
@@ -1,4 +1,8 @@
-performance_table_spec <- function(probs, reals, stratified_by = "probability_threshold") {
+performance_table_spec <- function(
+  probs,
+  reals,
+  stratified_by = "probability_threshold"
+) {
   performance_data <- prepare_performance_data(
     probs,
     reals,
@@ -19,10 +23,19 @@ test_that("performance table v2 represents one model and population", {
 
   expect_identical(spec$schemaVersion, "2.0")
   expect_identical(spec$type, "performance_table")
-  expect_identical(spec$evaluations, list(list(
-    id = "evaluation-1", population = "Population A", model = "Model A"
+  expect_identical(
+    spec$evaluations,
+    list(list(
+      id = "evaluation-1",
+      population = "Population A",
+      model = "Model A"
+    ))
+  )
+  expect_false(any(vapply(
+    spec$rows,
+    function(x) "seriesId" %in% names(x),
+    logical(1)
   )))
-  expect_false(any(vapply(spec$rows, function(x) "seriesId" %in% names(x), logical(1))))
 })
 
 test_that("performance table v2 shares population across models", {
@@ -58,7 +71,11 @@ test_that("performance table v2 preserves unknown model populations", {
     vapply(spec$evaluations, `[[`, "", "population"),
     c("Population A", "Population B")
   )
-  expect_false(any(vapply(spec$evaluations, function(x) "model" %in% names(x), logical(1))))
+  expect_false(any(vapply(
+    spec$evaluations,
+    function(x) "model" %in% names(x),
+    logical(1)
+  )))
 })
 
 test_that("performance table v2 evaluation IDs are deterministic", {
@@ -82,13 +99,22 @@ test_that("performance table v2 maps operating points and long metrics", {
   threshold_spec <- performance_table_spec(probs, reals)
   ppcr_spec <- performance_table_spec(probs, reals, "ppcr")
 
-  expect_identical(threshold_spec$rows[[1]]$operatingPoint$type, "probability_threshold")
+  expect_identical(
+    threshold_spec$rows[[1]]$operatingPoint$type,
+    "probability_threshold"
+  )
   expect_identical(ppcr_spec$rows[[1]]$operatingPoint$type, "ppcr")
-  expect_true(all(vapply(threshold_spec$rows[[1]]$values, function(x) {
-    identical(sort(names(x)), c("estimate", "metricId"))
-  }, logical(1))))
-  expect_true("net_benefit" %in% vapply(threshold_spec$metrics, `[[`, "", "id"))
-  expect_false("net_benefit" %in% vapply(ppcr_spec$metrics, `[[`, "", "id"))
+  expect_true(all(vapply(
+    threshold_spec$rows[[1]]$values,
+    function(x) identical(sort(names(x)), c("estimate", "metricId")),
+    logical(1)
+  )))
+  expect_true(
+    "net_benefit" %in% vapply(threshold_spec$metrics, `[[`, "", "id")
+  )
+  expect_false(
+    "net_benefit" %in% vapply(ppcr_spec$metrics, `[[`, "", "id")
+  )
 })
 
 test_that("performance table v2 distinguishes zero and missing", {
@@ -98,10 +124,13 @@ test_that("performance table v2 distinguishes zero and missing", {
     PPV = c(NaN, 0.5)
   )
   metadata <- data.frame(
-    model = "Model A", population = "Population A", evaluation = "Model A"
+    model = "Model A",
+    population = "Population A",
+    evaluation = "Model A"
   )
   spec <- rtichoke:::rtichoke_viz_performance_table_v2_spec(
-    performance_data, metadata
+    performance_data,
+    metadata
   )
 
   first <- spec$rows[[1]]$values
@@ -122,10 +151,13 @@ test_that("performance table v2 copies existing statistics without recomputation
     NB = -0.321
   )
   metadata <- data.frame(
-    model = "Model A", population = "Population A", evaluation = "Model A"
+    model = "Model A",
+    population = "Population A",
+    evaluation = "Model A"
   )
   spec <- rtichoke:::rtichoke_viz_performance_table_v2_spec(
-    performance_data, metadata
+    performance_data,
+    metadata
   )
   estimates <- stats::setNames(
     vapply(spec$rows[[1]]$values, function(x) x$estimate, numeric(1)),

--- a/tests/testthat/test-performance-table-v2.R
+++ b/tests/testthat/test-performance-table-v2.R
@@ -1,0 +1,145 @@
+performance_table_spec <- function(probs, reals, stratified_by = "probability_threshold") {
+  performance_data <- prepare_performance_data(
+    probs,
+    reals,
+    by = 0.5,
+    stratified_by = stratified_by
+  )
+  rtichoke:::rtichoke_viz_performance_table_v2_spec(
+    performance_data,
+    rtichoke:::build_evaluation_metadata(probs, reals),
+    stratified_by = stratified_by
+  )
+}
+
+test_that("performance table v2 represents one model and population", {
+  probs <- list("Model A" = c(0.1, 0.2, 0.8, 0.9))
+  reals <- list("Population A" = c(0, 0, 1, 1))
+  spec <- performance_table_spec(probs, reals)
+
+  expect_identical(spec$schemaVersion, "2.0")
+  expect_identical(spec$type, "performance_table")
+  expect_identical(spec$evaluations, list(list(
+    id = "evaluation-1", population = "Population A", model = "Model A"
+  )))
+  expect_false(any(vapply(spec$rows, function(x) "seriesId" %in% names(x), logical(1))))
+})
+
+test_that("performance table v2 shares population across models", {
+  probs <- list(
+    "Model A" = c(0.1, 0.2, 0.8, 0.9),
+    "Model B" = c(0.2, 0.3, 0.7, 0.8)
+  )
+  reals <- list("Population A" = c(0, 0, 1, 1))
+  spec <- performance_table_spec(probs, reals)
+
+  expect_identical(
+    vapply(spec$evaluations, `[[`, "", "population"),
+    c("Population A", "Population A")
+  )
+  expect_identical(
+    vapply(spec$evaluations, `[[`, "", "model"),
+    c("Model A", "Model B")
+  )
+})
+
+test_that("performance table v2 preserves unknown model populations", {
+  probs <- list(
+    "Population A" = c(0.1, 0.2, 0.8, 0.9),
+    "Population B" = c(0.2, 0.7, 0.3, 0.8)
+  )
+  reals <- list(
+    "Population A" = c(0, 0, 1, 1),
+    "Population B" = c(0, 1, 0, 1)
+  )
+  spec <- performance_table_spec(probs, reals)
+
+  expect_identical(
+    vapply(spec$evaluations, `[[`, "", "population"),
+    c("Population A", "Population B")
+  )
+  expect_false(any(vapply(spec$evaluations, function(x) "model" %in% names(x), logical(1))))
+})
+
+test_that("performance table v2 evaluation IDs are deterministic", {
+  probs <- list(
+    "Model A" = c(0.1, 0.2, 0.8, 0.9),
+    "Model B" = c(0.2, 0.3, 0.7, 0.8)
+  )
+  reals <- list("Population A" = c(0, 0, 1, 1))
+  first <- performance_table_spec(probs, reals)
+  second <- performance_table_spec(probs, reals)
+
+  expect_identical(
+    vapply(first$evaluations, `[[`, "", "id"),
+    vapply(second$evaluations, `[[`, "", "id")
+  )
+})
+
+test_that("performance table v2 maps operating points and long metrics", {
+  probs <- list("Model A" = c(0.1, 0.2, 0.8, 0.9))
+  reals <- list("Population A" = c(0, 0, 1, 1))
+  threshold_spec <- performance_table_spec(probs, reals)
+  ppcr_spec <- performance_table_spec(probs, reals, "ppcr")
+
+  expect_identical(threshold_spec$rows[[1]]$operatingPoint$type, "probability_threshold")
+  expect_identical(ppcr_spec$rows[[1]]$operatingPoint$type, "ppcr")
+  expect_true(all(vapply(threshold_spec$rows[[1]]$values, function(x) {
+    identical(sort(names(x)), c("estimate", "metricId"))
+  }, logical(1))))
+  expect_true("net_benefit" %in% vapply(threshold_spec$metrics, `[[`, "", "id"))
+  expect_false("net_benefit" %in% vapply(ppcr_spec$metrics, `[[`, "", "id"))
+})
+
+test_that("performance table v2 distinguishes zero and missing", {
+  performance_data <- tibble::tibble(
+    probability_threshold = c(0.2, 0.3),
+    sensitivity = c(0, NA_real_),
+    PPV = c(NaN, 0.5)
+  )
+  metadata <- data.frame(
+    model = "Model A", population = "Population A", evaluation = "Model A"
+  )
+  spec <- rtichoke:::rtichoke_viz_performance_table_v2_spec(
+    performance_data, metadata
+  )
+
+  first <- spec$rows[[1]]$values
+  second <- spec$rows[[2]]$values
+  expect_identical(first[[1]]$estimate, 0)
+  expect_null(first[[2]]$estimate)
+  expect_null(second[[1]]$estimate)
+  expect_identical(second[[2]]$estimate, 0.5)
+})
+
+test_that("performance table v2 copies existing statistics without recomputation", {
+  performance_data <- tibble::tibble(
+    probability_threshold = 0.25,
+    TP = 7,
+    sensitivity = 0.123,
+    specificity = 0.456,
+    lift = 9.876,
+    NB = -0.321
+  )
+  metadata <- data.frame(
+    model = "Model A", population = "Population A", evaluation = "Model A"
+  )
+  spec <- rtichoke:::rtichoke_viz_performance_table_v2_spec(
+    performance_data, metadata
+  )
+  estimates <- stats::setNames(
+    vapply(spec$rows[[1]]$values, function(x) x$estimate, numeric(1)),
+    vapply(spec$rows[[1]]$values, `[[`, "", "metricId")
+  )
+
+  expect_identical(unname(estimates[["true_positives"]]), 7)
+  expect_identical(unname(estimates[["sensitivity"]]), 0.123)
+  expect_identical(unname(estimates[["specificity"]]), 0.456)
+  expect_identical(unname(estimates[["lift"]]), 9.876)
+  expect_identical(unname(estimates[["net_benefit"]]), -0.321)
+})
+
+test_that("existing performance table defaults are unchanged", {
+  expect_identical(formals(create_performance_table)$output_type, "reactable")
+  expect_identical(formals(render_performance_table)$output_type, "reactable")
+})


### PR DESCRIPTION
## Summary
- add the smallest internal R producer for canonical `PerformanceTableSpec`
- map existing `prepare_performance_data()` output to long-form canonical metric values
- reuse explicit `build_evaluation_metadata()` semantics and deterministic evaluation IDs
- preserve model-known/model-unknown and population identity
- preserve probability-threshold vs PPCR operating-point semantics
- map `NA`/`NaN` estimates to canonical `null` while preserving numeric zero
- leave existing gt/reactable production rendering and calculations unchanged

## Boundary
- no public API changes
- no browser table activation
- no `seriesId`
- no statistical recomputation
- no time-dependent semantics added (the current static R performance-table path has none)
- no `ReportSpec`
- no `rtichoke_viz` changes

## Metric mapping
`TP→true_positives`, `TN→true_negatives`, `FP→false_positives`, `FN→false_negatives`, `sensitivity→sensitivity`, `specificity→specificity`, `FPR→false_positive_rate`, `PPV→ppv`, `NPV→npv`, `lift→lift`, `predicted_positives→predicted_positives`, `ppcr→ppcr`, `NB→net_benefit`.

## Tests
Covers one model/population, multiple models/shared population, multiple model-unknown populations, deterministic IDs, both operating points, long-form metrics, zero vs missing, no statistical recomputation, and unchanged reactable defaults.