### PR TITLE
Add canonical calibration v2 producer

### DIFF
--- a/R/calibration_v2.R
+++ b/R/calibration_v2.R
@@ -1,0 +1,176 @@
+#' Build a canonical rtichoke_viz v2 calibration specification
+#'
+#' Adapt already-computed calibration curve data plus explicit semantic
+#' evaluation metadata into the canonical rtichoke_viz v2 contract. This
+#' helper does not calculate calibration statistics and is not wired into
+#' production rendering.
+#'
+#' @param calibration_curve_list Output from [create_calibration_curve_list()].
+#' @param evaluation_metadata Output from [build_evaluation_metadata()].
+#' @param method Calibration representation to embed: `"discrete"` or
+#'   `"smooth"`.
+#'
+#' @return A nested list representing a canonical calibration v2 specification.
+#' @noRd
+rtichoke_viz_calibration_v2_spec <- function(
+  calibration_curve_list,
+  evaluation_metadata,
+  method = c("discrete", "smooth")
+) {
+  method <- match.arg(method)
+  required_metadata <- c("model", "population", "evaluation")
+  missing_metadata <- setdiff(required_metadata, names(evaluation_metadata))
+  if (length(missing_metadata) > 0L) {
+    stop(
+      "Calibration evaluation metadata is missing columns: ",
+      paste(missing_metadata, collapse = ", "),
+      call. = FALSE
+    )
+  }
+  if (nrow(evaluation_metadata) == 0L) {
+    stop(
+      "Calibration evaluation metadata must contain at least one evaluation",
+      call. = FALSE
+    )
+  }
+
+  calibration_data <- if (method == "discrete") {
+    calibration_curve_list$deciles_dat
+  } else {
+    calibration_curve_list$smooth_dat
+  }
+  histogram <- calibration_curve_list$histogram_for_calibration
+
+  required_data_columns <- c("reference_group", "x", "y")
+  if (method == "discrete") {
+    required_data_columns <- c(
+      required_data_columns,
+      "sum_reals",
+      "total_obs"
+    )
+  }
+  missing_data_columns <- setdiff(
+    required_data_columns,
+    names(calibration_data)
+  )
+  if (length(missing_data_columns) > 0L) {
+    stop(
+      "Calibration data is missing columns: ",
+      paste(missing_data_columns, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  required_histogram_columns <- c("reference_group", "mids", "counts")
+  missing_histogram_columns <- setdiff(
+    required_histogram_columns,
+    names(histogram)
+  )
+  if (length(missing_histogram_columns) > 0L) {
+    stop(
+      "Calibration histogram is missing columns: ",
+      paste(missing_histogram_columns, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  groups <- unique(c(
+    as.character(calibration_data$reference_group),
+    as.character(histogram$reference_group)
+  ))
+  metadata_groups <- as.character(evaluation_metadata$evaluation)
+  missing_groups <- setdiff(groups, metadata_groups)
+  if (length(missing_groups) > 0L) {
+    stop(
+      "Calibration rows are missing evaluation metadata: ",
+      paste(missing_groups, collapse = ", "),
+      call. = FALSE
+    )
+  }
+
+  used_metadata <- evaluation_metadata[
+    evaluation_metadata$evaluation %in% groups,
+    ,
+    drop = FALSE
+  ]
+  used_groups <- as.character(used_metadata$evaluation)
+  evaluation_ids <- stats::setNames(
+    paste0("evaluation-", seq_len(nrow(used_metadata))),
+    used_groups
+  )
+  series_ids <- stats::setNames(
+    paste0("series-", seq_len(nrow(used_metadata))),
+    used_groups
+  )
+
+  evaluations <- lapply(seq_len(nrow(used_metadata)), function(i) {
+    metadata <- used_metadata[i, , drop = FALSE]
+    evaluation <- list(
+      id = unname(evaluation_ids[[as.character(metadata$evaluation)]]),
+      population = as.character(metadata$population)
+    )
+    if (!is.na(metadata$model) && nzchar(metadata$model)) {
+      evaluation$model <- as.character(metadata$model)
+    }
+    evaluation
+  })
+
+  series <- lapply(seq_len(nrow(used_metadata)), function(i) {
+    metadata <- used_metadata[i, , drop = FALSE]
+    group <- as.character(metadata$evaluation)
+    model_known <- !is.na(metadata$model) && nzchar(metadata$model)
+    display_value <- if (model_known) {
+      as.character(metadata$model)
+    } else {
+      as.character(metadata$population)
+    }
+    list(
+      id = unname(series_ids[[group]]),
+      evaluationId = unname(evaluation_ids[[group]]),
+      display = list(
+        label = display_value,
+        group = display_value,
+        role = if (model_known) "model" else "population"
+      )
+    )
+  })
+
+  data <- lapply(seq_len(nrow(calibration_data)), function(i) {
+    group <- as.character(calibration_data$reference_group[[i]])
+    datum <- list(
+      seriesId = unname(series_ids[[group]]),
+      predicted = as.numeric(calibration_data$x[[i]]),
+      observed = as.numeric(calibration_data$y[[i]]),
+      method = method
+    )
+    if (method == "discrete") {
+      datum$events <- as.numeric(calibration_data$sum_reals[[i]])
+      datum$total <- as.numeric(calibration_data$total_obs[[i]])
+    }
+    datum
+  })
+
+  distribution <- lapply(seq_len(nrow(histogram)), function(i) {
+    group <- as.character(histogram$reference_group[[i]])
+    list(
+      seriesId = unname(series_ids[[group]]),
+      midpoint = as.numeric(histogram$mids[[i]]),
+      count = as.numeric(histogram$counts[[i]]),
+      binWidth = 0.01
+    )
+  })
+
+  list(
+    schemaVersion = "2.0",
+    type = "calibration",
+    evaluations = evaluations,
+    series = series,
+    data = data,
+    distribution = distribution,
+    x = "predicted",
+    y = "observed",
+    xAxis = list(label = "Predicted probability", domain = c(0, 1)),
+    yAxis = list(label = "Observed probability", domain = c(0, 1)),
+    references = list(list(type = "identity", scope = "global"))
+  )
+}

--- a/tests/testthat/test-calibration-v2.R
+++ b/tests/testthat/test-calibration-v2.R
@@ -59,10 +59,13 @@ test_that("calibration v2 producer emits a complete canonical discrete spec", {
   expect_identical(spec$type, "calibration")
   expect_identical(spec$x, "predicted")
   expect_identical(spec$y, "observed")
-  expect_identical(spec$references, list(list(
-    type = "identity",
-    scope = "global"
-  )))
+  expect_identical(
+    spec$references,
+    list(list(
+      type = "identity",
+      scope = "global"
+    ))
+  )
   expect_true(all(vapply(spec$data, `[[`, "", "method") == "discrete"))
   expect_true(all(vapply(spec$data, function(x) {
     all(c("events", "total") %in% names(x))

--- a/tests/testthat/test-calibration-v2.R
+++ b/tests/testthat/test-calibration-v2.R
@@ -1,27 +1,36 @@
 calibration_v2_fixture <- function(groups = "Model A") {
-  deciles <- do.call(rbind, lapply(seq_along(groups), function(i) {
-    data.frame(
-      reference_group = groups[[i]],
-      x = c(0.2, 0.8),
-      y = c(0.25, 0.75) + (i - 1) * 0.01,
-      sum_reals = c(5, 15) + i,
-      total_obs = c(20, 20)
-    )
-  }))
-  smooth <- do.call(rbind, lapply(seq_along(groups), function(i) {
-    data.frame(
-      reference_group = groups[[i]],
-      x = c(0.1, 0.5, 0.9),
-      y = c(0.12, 0.52, 0.88) + (i - 1) * 0.01
-    )
-  }))
-  histogram <- do.call(rbind, lapply(seq_along(groups), function(i) {
-    data.frame(
-      reference_group = groups[[i]],
-      mids = c(0.005, 0.015),
-      counts = c(7, 11) + i
-    )
-  }))
+  deciles <- do.call(
+    rbind,
+    lapply(seq_along(groups), function(i) {
+      data.frame(
+        reference_group = groups[[i]],
+        x = c(0.2, 0.8),
+        y = c(0.25, 0.75) + (i - 1) * 0.01,
+        sum_reals = c(5, 15) + i,
+        total_obs = c(20, 20)
+      )
+    })
+  )
+  smooth <- do.call(
+    rbind,
+    lapply(seq_along(groups), function(i) {
+      data.frame(
+        reference_group = groups[[i]],
+        x = c(0.1, 0.5, 0.9),
+        y = c(0.12, 0.52, 0.88) + (i - 1) * 0.01
+      )
+    })
+  )
+  histogram <- do.call(
+    rbind,
+    lapply(seq_along(groups), function(i) {
+      data.frame(
+        reference_group = groups[[i]],
+        mids = c(0.005, 0.015),
+        counts = c(7, 11) + i
+      )
+    })
+  )
   list(
     deciles_dat = deciles,
     smooth_dat = smooth,

--- a/tests/testthat/test-calibration-v2.R
+++ b/tests/testthat/test-calibration-v2.R
@@ -1,0 +1,231 @@
+calibration_v2_fixture <- function(groups = "Model A") {
+  deciles <- do.call(rbind, lapply(seq_along(groups), function(i) {
+    data.frame(
+      reference_group = groups[[i]],
+      x = c(0.2, 0.8),
+      y = c(0.25, 0.75) + (i - 1) * 0.01,
+      sum_reals = c(5, 15) + i,
+      total_obs = c(20, 20)
+    )
+  }))
+  smooth <- do.call(rbind, lapply(seq_along(groups), function(i) {
+    data.frame(
+      reference_group = groups[[i]],
+      x = c(0.1, 0.5, 0.9),
+      y = c(0.12, 0.52, 0.88) + (i - 1) * 0.01
+    )
+  }))
+  histogram <- do.call(rbind, lapply(seq_along(groups), function(i) {
+    data.frame(
+      reference_group = groups[[i]],
+      mids = c(0.005, 0.015),
+      counts = c(7, 11) + i
+    )
+  }))
+  list(
+    deciles_dat = deciles,
+    smooth_dat = smooth,
+    histogram_for_calibration = histogram
+  )
+}
+
+calibration_v2_metadata <- function(
+  groups = "Model A",
+  model_known = TRUE,
+  shared_population = TRUE
+) {
+  data.frame(
+    model = if (model_known) groups else rep(NA_character_, length(groups)),
+    population = if (shared_population) {
+      rep("Population A", length(groups))
+    } else {
+      groups
+    },
+    evaluation = groups,
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("calibration v2 producer emits a complete canonical discrete spec", {
+  calibration <- calibration_v2_fixture()
+  metadata <- calibration_v2_metadata()
+  spec <- rtichoke:::rtichoke_viz_calibration_v2_spec(
+    calibration,
+    metadata,
+    "discrete"
+  )
+
+  expect_identical(spec$schemaVersion, "2.0")
+  expect_identical(spec$type, "calibration")
+  expect_identical(spec$x, "predicted")
+  expect_identical(spec$y, "observed")
+  expect_identical(spec$references, list(list(
+    type = "identity",
+    scope = "global"
+  )))
+  expect_true(all(vapply(spec$data, `[[`, "", "method") == "discrete"))
+  expect_true(all(vapply(spec$data, function(x) {
+    all(c("events", "total") %in% names(x))
+  }, logical(1))))
+})
+
+test_that("calibration v2 identities are deterministic", {
+  calibration <- calibration_v2_fixture(c("Model A", "Model B"))
+  metadata <- calibration_v2_metadata(c("Model A", "Model B"))
+  first <- rtichoke:::rtichoke_viz_calibration_v2_spec(
+    calibration,
+    metadata
+  )
+  second <- rtichoke:::rtichoke_viz_calibration_v2_spec(
+    calibration,
+    metadata
+  )
+
+  expect_identical(first$evaluations, second$evaluations)
+  expect_identical(first$series, second$series)
+  expect_identical(
+    vapply(first$evaluations, `[[`, "", "id"),
+    c("evaluation-1", "evaluation-2")
+  )
+  expect_identical(
+    vapply(first$series, `[[`, "", "id"),
+    c("series-1", "series-2")
+  )
+})
+
+test_that("one model and multiple models preserve semantic metadata", {
+  one <- rtichoke:::rtichoke_viz_calibration_v2_spec(
+    calibration_v2_fixture("Model A"),
+    calibration_v2_metadata("Model A")
+  )
+  expect_identical(one$evaluations[[1]]$model, "Model A")
+  expect_identical(one$evaluations[[1]]$population, "Population A")
+
+  groups <- c("Model A", "Model B")
+  several <- rtichoke:::rtichoke_viz_calibration_v2_spec(
+    calibration_v2_fixture(groups),
+    calibration_v2_metadata(groups)
+  )
+  expect_identical(
+    vapply(several$evaluations, `[[`, "", "model"),
+    groups
+  )
+  expect_identical(
+    vapply(several$evaluations, `[[`, "", "population"),
+    rep("Population A", 2)
+  )
+})
+
+test_that("multiple populations and model-unknown semantics are preserved", {
+  groups <- c("Train", "Test")
+  spec <- rtichoke:::rtichoke_viz_calibration_v2_spec(
+    calibration_v2_fixture(groups),
+    calibration_v2_metadata(
+      groups,
+      model_known = FALSE,
+      shared_population = FALSE
+    )
+  )
+
+  expect_identical(
+    vapply(spec$evaluations, `[[`, "", "population"),
+    groups
+  )
+  expect_true(all(vapply(spec$evaluations, function(x) {
+    !"model" %in% names(x)
+  }, logical(1))))
+  expect_identical(
+    vapply(spec$series, function(x) x$display$role, ""),
+    rep("population", 2)
+  )
+})
+
+test_that("distribution rows retain series ownership", {
+  groups <- c("Model A", "Model B")
+  spec <- rtichoke:::rtichoke_viz_calibration_v2_spec(
+    calibration_v2_fixture(groups),
+    calibration_v2_metadata(groups)
+  )
+
+  expect_identical(
+    vapply(spec$distribution, `[[`, "", "seriesId"),
+    rep(c("series-1", "series-2"), each = 2)
+  )
+  expect_true(all(
+    vapply(spec$distribution, `[[`, "", "seriesId") %in%
+      vapply(spec$series, `[[`, "", "id")
+  ))
+})
+
+test_that("calibration statistics are passed through without recomputation", {
+  calibration <- calibration_v2_fixture()
+  calibration$deciles_dat$x <- c(0.123456, 0.876543)
+  calibration$deciles_dat$y <- c(0.234567, 0.765432)
+  calibration$deciles_dat$sum_reals <- c(3, 17)
+  calibration$deciles_dat$total_obs <- c(19, 23)
+
+  spec <- rtichoke:::rtichoke_viz_calibration_v2_spec(
+    calibration,
+    calibration_v2_metadata()
+  )
+
+  expect_identical(
+    vapply(spec$data, `[[`, 0, "predicted"),
+    calibration$deciles_dat$x
+  )
+  expect_identical(
+    vapply(spec$data, `[[`, 0, "observed"),
+    calibration$deciles_dat$y
+  )
+  expect_identical(
+    vapply(spec$data, `[[`, 0, "events"),
+    as.numeric(calibration$deciles_dat$sum_reals)
+  )
+  expect_identical(
+    vapply(spec$data, `[[`, 0, "total"),
+    as.numeric(calibration$deciles_dat$total_obs)
+  )
+})
+
+test_that("smooth calibration uses existing smooth output", {
+  calibration <- calibration_v2_fixture()
+  spec <- rtichoke:::rtichoke_viz_calibration_v2_spec(
+    calibration,
+    calibration_v2_metadata(),
+    "smooth"
+  )
+
+  expect_true(all(vapply(spec$data, `[[`, "", "method") == "smooth"))
+  expect_identical(
+    vapply(spec$data, `[[`, 0, "predicted"),
+    calibration$smooth_dat$x
+  )
+  expect_identical(
+    vapply(spec$data, `[[`, 0, "observed"),
+    calibration$smooth_dat$y
+  )
+  expect_true(all(vapply(spec$data, function(x) {
+    !any(c("events", "total") %in% names(x))
+  }, logical(1))))
+})
+
+test_that("ReportSpec embeds produced calibration unchanged", {
+  spec <- rtichoke:::rtichoke_viz_calibration_v2_spec(
+    calibration_v2_fixture(),
+    calibration_v2_metadata()
+  )
+  report <- rtichoke:::rtichoke_viz_report_spec(spec)
+
+  expect_identical(report$components[[1]]$id, "calibration")
+  expect_identical(report$components[[1]]$spec, spec)
+})
+
+test_that("existing v1 calibration producer remains unchanged", {
+  calibration <- calibration_v2_fixture()
+  v1 <- rtichoke:::rtichoke_viz_calibration_spec(calibration)
+
+  expect_identical(v1$schemaVersion, "1.0")
+  expect_identical(v1$type, "calibration")
+  expect_true(all(vapply(v1$data, `[[`, "", "method") == "discrete"))
+  expect_identical(v1$references, list(list(type = "identity")))
+})

--- a/tests/testthat/test-calibration-v2.R
+++ b/tests/testthat/test-calibration-v2.R
@@ -1,3 +1,5 @@
+# fmt: skip file
+
 calibration_v2_fixture <- function(groups = "Model A") {
   deciles <- do.call(
     rbind,


### PR DESCRIPTION
## Summary

Adds the smallest internal canonical R calibration-v2 producer, adapting the existing already-computed calibration outputs plus explicit evaluation metadata into a complete standalone `CalibrationV2Spec`.

- adds `rtichoke_viz_calibration_v2_spec()`
- supports existing discrete and smooth calibration outputs
- preserves model-known/model-unknown and population semantics
- gives distribution rows explicit `seriesId` ownership
- preserves the existing v1/public calibration path unchanged
- proves the produced spec is embedded unchanged by `rtichoke_viz_report_spec()`

## Architecture

No calibration statistics are calculated in the new builder. It consumes `deciles_dat` or `smooth_dat` and `histogram_for_calibration` from the existing `create_calibration_curve_list()` production path, together with `build_evaluation_metadata()`-shaped semantic metadata.

No `rtichoke_viz`, ReportSpec, renderer migration, vendoring, or public summary-report changes are included.

## Tests

Focused tests cover canonical shape, deterministic evaluation/series IDs, one/multiple models, multiple populations, model-unknown semantics, distribution ownership, statistical pass-through, smooth output pass-through, ReportSpec composition, and unchanged v1 calibration production.