### PR TITLE
Add opt-in canonical browser summary reports

### DIFF
--- a/R/create_summary_report.R
+++ b/R/create_summary_report.R
@@ -2,7 +2,11 @@
 #'
 #' @inheritParams create_roc_curve
 #' @inheritParams rmarkdown::render
-#' @param output_file The name of the output file
+#' @param output_file The name of the output file.
+#' @param renderer Summary-report rendering backend. `"rmarkdown"` preserves
+#'   the existing report and remains the default. `"browser"` renders the
+#'   canonical PerformanceTable, ROC, and discrete calibration components via
+#'   the vendored rtichoke_viz ReportSpec renderer.
 #'
 #' @export
 #'
@@ -11,6 +15,12 @@
 #' create_summary_report(
 #'   probs = list(example_dat$estimated_probabilities),
 #'   reals = list(example_dat$outcome)
+#' )
+#'
+#' create_summary_report(
+#'   probs = list(example_dat$estimated_probabilities),
+#'   reals = list(example_dat$outcome),
+#'   renderer = "browser"
 #' )
 #'
 #' create_summary_report(
@@ -42,21 +52,90 @@ create_summary_report <- function(
   reals,
   interactive = TRUE,
   output_file = "summary_report.html",
-  output_dir = getwd()
+  output_dir = getwd(),
+  renderer = c("rmarkdown", "browser")
 ) {
-  rmarkdown::render(
-    file.path(
-      system.file(package = "rtichoke"),
-      "summary_report_template.Rmd"
-    ),
-    params = list(
-      probs = probs,
-      reals = reals,
-      interactive = interactive
-    ),
-    output_file = output_file,
-    output_dir = output_dir
-  )
+  renderer <- match.arg(renderer)
+
+  if (renderer == "rmarkdown") {
+    rmarkdown::render(
+      file.path(
+        system.file(package = "rtichoke"),
+        "summary_report_template.Rmd"
+      ),
+      params = list(
+        probs = probs,
+        reals = reals,
+        interactive = interactive
+      ),
+      output_file = output_file,
+      output_dir = output_dir
+    )
+  } else {
+    report_spec <- summary_report_browser_spec(probs, reals)
+    report <- render_rtichoke_viz_report_browser(report_spec)
+
+    dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+    htmltools::save_html(
+      report,
+      file = file.path(output_dir, output_file),
+      libdir = "lib"
+    )
+  }
 
   print(glue::glue("{output_file} was rendered in {output_dir}"))
+}
+
+
+#' Build the canonical first public browser summary report
+#'
+#' Reuse the package's existing statistical preparation and canonical component
+#' builders, then assemble the resulting complete standalone specs into a
+#' ReportSpec. This helper does not dispatch report components or alter their
+#' identities.
+#'
+#' @param probs A list of vectors of estimated probabilities.
+#' @param reals A list of vectors of binary outcomes.
+#'
+#' @return A canonical ReportSpec.
+#' @noRd
+summary_report_browser_spec <- function(probs, reals) {
+  check_probs_input(probs)
+  check_real_input(reals)
+
+  performance_data <- prepare_performance_data(
+    probs = probs,
+    reals = reals
+  )
+  evaluation_metadata <- build_evaluation_metadata(probs, reals)
+  calibration_curve_list <- create_calibration_curve_list(
+    probs = probs,
+    reals = reals
+  )
+
+  performance_table <- rtichoke_viz_performance_table_v2_spec(
+    performance_data,
+    evaluation_metadata
+  )
+  roc <- rtichoke_viz_roc_v2_spec(
+    performance_data,
+    evaluation_metadata
+  )
+  calibration <- rtichoke_viz_calibration_v2_spec(
+    calibration_curve_list,
+    evaluation_metadata,
+    method = "discrete"
+  )
+
+  rtichoke_viz_report_spec(
+    performance_table,
+    roc,
+    calibration,
+    title = "Summary Report",
+    component_titles = list(
+      "Performance Table",
+      "ROC",
+      "Calibration"
+    )
+  )
 }

--- a/R/create_summary_report.R
+++ b/R/create_summary_report.R
@@ -58,16 +58,10 @@ create_summary_report <- function(
   renderer <- match.arg(renderer)
 
   if (renderer == "rmarkdown") {
-    rmarkdown::render(
-      file.path(
-        system.file(package = "rtichoke"),
-        "summary_report_template.Rmd"
-      ),
-      params = list(
-        probs = probs,
-        reals = reals,
-        interactive = interactive
-      ),
+    render_summary_report_rmarkdown(
+      probs = probs,
+      reals = reals,
+      interactive = interactive,
       output_file = output_file,
       output_dir = output_dir
     )
@@ -78,12 +72,42 @@ create_summary_report <- function(
     dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
     htmltools::save_html(
       report,
-      file = file.path(output_dir, output_file),
+      file = file.path(output_dir, basename(output_file)),
       libdir = "lib"
     )
   }
 
   print(glue::glue("{output_file} was rendered in {output_dir}"))
+}
+
+
+#' Render the historical RMarkdown summary report
+#'
+#' Keep the pre-existing summary-report lifecycle isolated so the public
+#' renderer switch cannot accidentally migrate the default backend.
+#'
+#' @inheritParams create_summary_report
+#' @noRd
+render_summary_report_rmarkdown <- function(
+  probs,
+  reals,
+  interactive,
+  output_file,
+  output_dir
+) {
+  rmarkdown::render(
+    file.path(
+      system.file(package = "rtichoke"),
+      "summary_report_template.Rmd"
+    ),
+    params = list(
+      probs = probs,
+      reals = reals,
+      interactive = interactive
+    ),
+    output_file = output_file,
+    output_dir = output_dir
+  )
 }
 
 

--- a/man/create_summary_report.Rd
+++ b/man/create_summary_report.Rd
@@ -9,7 +9,8 @@ create_summary_report(
   reals,
   interactive = TRUE,
   output_file = "summary_report.html",
-  output_dir = getwd()
+  output_dir = getwd(),
+  renderer = c("rmarkdown", "browser")
 )
 }
 \arguments{
@@ -21,7 +22,7 @@ create_summary_report(
 \item{interactive}{whether the plot should be interactive
 plots}
 
-\item{output_file}{The name of the output file}
+\item{output_file}{The name of the output file.}
 
 \item{output_dir}{The output directory for the rendered \code{output_file}.
 This allows for a choice of an alternate directory to which the output file
@@ -29,6 +30,11 @@ should be written (the default output directory of that of the input file).
 If a path is provided with a filename in \code{output_file} the directory
 specified here will take precedence. Please note that any directory path
 provided will create any necessary directories if they do not exist.}
+
+\item{renderer}{Summary-report rendering backend. \code{"rmarkdown"} preserves
+the existing report and remains the default. \code{"browser"} renders the
+canonical PerformanceTable, ROC, and discrete calibration components via
+the vendored rtichoke_viz ReportSpec renderer.}
 }
 \description{
 Create a summary report
@@ -38,6 +44,12 @@ Create a summary report
 create_summary_report(
   probs = list(example_dat$estimated_probabilities),
   reals = list(example_dat$outcome)
+)
+
+create_summary_report(
+  probs = list(example_dat$estimated_probabilities),
+  reals = list(example_dat$outcome),
+  renderer = "browser"
 )
 
 create_summary_report(

--- a/tests/testthat/test-summary-report-browser.R
+++ b/tests/testthat/test-summary-report-browser.R
@@ -1,0 +1,112 @@
+summary_report_test_data <- function() {
+  list(
+    probs = list("Model A" = seq(0.01, 0.99, length.out = 100)),
+    reals = list("Population A" = c(rep(0, 50), rep(1, 50)))
+  )
+}
+
+
+test_that("summary report keeps RMarkdown as the default backend", {
+  dat <- summary_report_test_data()
+  rmarkdown_called <- FALSE
+
+  testthat::local_mocked_bindings(
+    render_summary_report_rmarkdown = function(...) {
+      rmarkdown_called <<- TRUE
+      invisible(NULL)
+    },
+    summary_report_browser_spec = function(...) {
+      stop("browser backend must not run")
+    },
+    .package = "rtichoke"
+  )
+
+  expect_message(
+    create_summary_report(
+      probs = dat$probs,
+      reals = dat$reals,
+      output_file = "legacy.html",
+      output_dir = tempdir()
+    ),
+    NA
+  )
+  expect_true(rmarkdown_called)
+  expect_identical(formals(create_summary_report)$renderer, c("rmarkdown", "browser"))
+})
+
+
+test_that("browser summary report uses real canonical first-report components", {
+  dat <- summary_report_test_data()
+  report <- rtichoke:::summary_report_browser_spec(dat$probs, dat$reals)
+
+  expect_identical(report$schemaVersion, "1.0")
+  expect_identical(report$type, "report")
+  expect_identical(report$title, "Summary Report")
+  expect_identical(
+    vapply(report$components, `[[`, "", "id"),
+    c("performance-table", "roc", "calibration")
+  )
+  expect_identical(
+    vapply(report$components, function(x) x$spec$type, character(1)),
+    c("performance_table", "roc", "calibration")
+  )
+  expect_identical(
+    vapply(report$components, `[[`, "", "title"),
+    c("Performance Table", "ROC", "Calibration")
+  )
+  expect_identical(report$components[[3]]$spec$data[[1]]$method, "discrete")
+})
+
+
+test_that("browser summary report preserves component-local evaluation identity", {
+  dat <- summary_report_test_data()
+  report <- rtichoke:::summary_report_browser_spec(dat$probs, dat$reals)
+
+  evaluation_ids <- vapply(
+    report$components,
+    function(component) component$spec$evaluations[[1]]$id,
+    character(1)
+  )
+
+  expect_identical(evaluation_ids, rep("evaluation-1", 3))
+  expect_false("evaluations" %in% names(report))
+  expect_identical(
+    report$components[[2]]$spec$evaluations[[1]]$population,
+    "Population A"
+  )
+  expect_identical(
+    report$components[[3]]$spec$evaluations[[1]]$population,
+    "Population A"
+  )
+})
+
+
+test_that("public browser renderer writes shared renderReport HTML", {
+  dat <- summary_report_test_data()
+  output_dir <- tempfile("rtichoke-summary-")
+  output_file <- file.path("ignored-subdir", "browser.html")
+
+  expect_message(
+    create_summary_report(
+      probs = dat$probs,
+      reals = dat$reals,
+      output_file = output_file,
+      output_dir = output_dir,
+      renderer = "browser"
+    ),
+    NA
+  )
+
+  rendered_file <- file.path(output_dir, "browser.html")
+  expect_true(file.exists(rendered_file))
+
+  html <- paste(readLines(rendered_file, warn = FALSE), collapse = "\n")
+  expect_match(html, "renderReport", fixed = TRUE)
+  expect_match(html, "rtichoke-viz-0.5.0", fixed = TRUE)
+  expect_match(html, '"id":"performance-table"', fixed = TRUE)
+  expect_match(html, '"id":"roc"', fixed = TRUE)
+  expect_match(html, '"id":"calibration"', fixed = TRUE)
+  expect_false(grepl("renderRocV2", html, fixed = TRUE))
+  expect_false(grepl("renderCalibrationV2", html, fixed = TRUE))
+  expect_false(grepl("renderPerformanceTable", html, fixed = TRUE))
+})

--- a/tests/testthat/test-summary-report-browser.R
+++ b/tests/testthat/test-summary-report-browser.R
@@ -1,7 +1,7 @@
 summary_report_test_data <- function() {
   list(
     probs = list("Model A" = seq(0.01, 0.99, length.out = 100)),
-    reals = list("Population A" = c(rep(0, 50), rep(1, 50)))
+    reals = list("Population A" = rep(c(0, 1), 50))
   )
 }
 
@@ -31,7 +31,10 @@ test_that("summary report keeps RMarkdown as the default backend", {
     NA
   )
   expect_true(rmarkdown_called)
-  expect_identical(formals(create_summary_report)$renderer, c("rmarkdown", "browser"))
+  expect_identical(
+    eval(formals(create_summary_report)$renderer),
+    c("rmarkdown", "browser")
+  )
 })
 
 


### PR DESCRIPTION
## Summary

Expose the existing canonical browser ReportSpec architecture through the public `create_summary_report()` API without changing the default backend.

### Public API

- adds `renderer = c("rmarkdown", "browser")` to `create_summary_report()`;
- keeps `"rmarkdown"` as the default and preserves the historical RMarkdown path;
- adds an opt-in `"browser"` path.

### Browser path

The browser backend reuses existing production calculations and canonical builders:

`probs/reals`
→ `prepare_performance_data()` / `create_calibration_curve_list()`
→ canonical PerformanceTable + ROC + calibration-v2 specs
→ `rtichoke_viz_report_spec()`
→ `render_rtichoke_viz_report_browser()`
→ vendored immutable rtichoke_viz v0.5.0 `renderReport()`.

No R-side report component dispatcher is added. Complete embedded canonical component specs remain unchanged, and equal evaluation IDs remain component-local.

### First public browser report

- PerformanceTable
- ROC
- discrete calibration-v2

### Output behavior

Browser output uses `htmltools::save_html()` and preserves `output_dir` precedence over any directory embedded in `output_file`.

### Tests

Adds focused coverage for:

- unchanged/default RMarkdown backend selection;
- explicit browser selection;
- real canonical first-report components;
- deterministic component IDs/order;
- component-local duplicate evaluation IDs;
- shared `renderReport()` HTML with no R-side component dispatch;
- output-file behavior.

### Scope

No changes to rtichoke_viz, statistics, the RMarkdown template, Plotly/ggplot2 paths, standalone browser charts, or the existing default summary-report behavior.

Do not merge automatically.