### PR TITLE
Fix blank local browser summary reports

### DIFF
--- a/R/report_browser.R
+++ b/R/report_browser.R
@@ -15,16 +15,20 @@ render_rtichoke_viz_report_browser <- function(report_spec) {
   json <- jsonlite::toJSON(report_spec, auto_unbox = TRUE, digits = NA)
   json <- gsub("</", "<\\/", json, fixed = TRUE)
 
+  vendor_dir <- system.file("rtichoke-viz", package = "rtichoke")
+  bundle <- paste(
+    readLines(file.path(vendor_dir, "rtichoke-viz.js"), warn = FALSE),
+    collapse = "\n"
+  )
+  bundle <- gsub("</", "<\\/", bundle, fixed = TRUE)
+
   dependency <- htmltools::htmlDependency(
     name = "rtichoke-viz",
     version = "0.5.0",
-    src = c(file = system.file("rtichoke-viz", package = "rtichoke")),
-    script = list(src = "rtichoke-viz.js", type = "module"),
+    src = c(file = vendor_dir),
     stylesheet = "rtichoke-viz.css"
   )
-  script <- paste0(
-    "import { renderReport } from ",
-    "'./lib/rtichoke-viz-0.5.0/rtichoke-viz.js';\n",
+  initializer <- paste0(
     "const spec = JSON.parse(document.querySelector('#",
     id,
     "-spec').textContent);\n",
@@ -32,6 +36,7 @@ render_rtichoke_viz_report_browser <- function(report_spec) {
     id,
     "').append(renderReport(spec));"
   )
+  script <- paste(bundle, initializer, sep = "\n")
 
   htmltools::browsable(htmltools::attachDependencies(
     htmltools::tagList(

--- a/tests/testthat/test-report-browser.R
+++ b/tests/testthat/test-report-browser.R
@@ -54,15 +54,20 @@ test_that("browser ReportSpec path delegates complete report to renderReport", {
   browser <- rtichoke:::render_rtichoke_viz_report_browser(report)
   html <- as.character(browser)
   expected_json <- jsonlite::toJSON(report, auto_unbox = TRUE, digits = NA)
+  renderer_source <- paste(
+    deparse(body(rtichoke:::render_rtichoke_viz_report_browser)),
+    collapse = "\n"
+  )
 
   expect_s3_class(browser, "shiny.tag.list")
   expect_match(html, "renderReport", fixed = TRUE)
   expect_match(html, "rtichoke-viz-0.5.0", fixed = TRUE)
   expect_match(html, expected_json, fixed = TRUE)
   expect_identical(report, before)
-  expect_false(grepl("renderRocV2", html, fixed = TRUE))
-  expect_false(grepl("renderCalibrationV2", html, fixed = TRUE))
-  expect_false(grepl("renderPerformanceTable", html, fixed = TRUE))
+  expect_false(grepl("renderRocV2", renderer_source, fixed = TRUE))
+  expect_false(grepl("renderCalibrationV2", renderer_source, fixed = TRUE))
+  expect_false(grepl("renderPerformanceTable", renderer_source, fixed = TRUE))
+  expect_false(grepl("import { renderReport } from", html, fixed = TRUE))
 })
 
 test_that("browser report preserves component order and deterministic ids", {

--- a/tests/testthat/test-summary-report-browser.R
+++ b/tests/testthat/test-summary-report-browser.R
@@ -127,7 +127,25 @@ test_that("public browser renderer writes file-safe shared renderReport HTML", {
 })
 
 
+test_that("browser output_dir still takes precedence over output_file path", {
+  dat <- summary_report_test_data()
+  output_dir <- tempfile("rtichoke-summary-path-")
+
+  create_summary_report(
+    probs = dat$probs,
+    reals = dat$reals,
+    renderer = "browser",
+    output_file = file.path("ignored-subdir", "browser.html"),
+    output_dir = output_dir
+  )
+
+  expect_true(file.exists(file.path(output_dir, "browser.html")))
+  expect_false(file.exists(file.path(output_dir, "ignored-subdir", "browser.html")))
+})
+
+
 test_that("public browser report initializes from a local file", {
+  skip_on_os("windows")
   browser <- find_headless_browser()
   skip_if(!nzchar(browser), "No headless Chromium/Chrome available")
 

--- a/tests/testthat/test-summary-report-browser.R
+++ b/tests/testthat/test-summary-report-browser.R
@@ -5,6 +5,17 @@ summary_report_test_data <- function() {
   )
 }
 
+find_headless_browser <- function() {
+  candidates <- Sys.which(c(
+    "chromium",
+    "chromium-browser",
+    "google-chrome",
+    "google-chrome-stable"
+  ))
+  candidates <- unname(candidates[nzchar(candidates)])
+  if (length(candidates) == 0L) "" else candidates[[1]]
+}
+
 
 test_that("summary report keeps RMarkdown as the default backend", {
   dat <- summary_report_test_data()
@@ -84,23 +95,21 @@ test_that("browser summary report preserves component-local evaluation identity"
 })
 
 
-test_that("public browser renderer writes shared renderReport HTML", {
-  dat <- summary_report_test_data()
+test_that("public browser renderer writes file-safe shared renderReport HTML", {
   output_dir <- tempfile("rtichoke-summary-")
-  output_file <- file.path("ignored-subdir", "browser.html")
 
   expect_message(
     create_summary_report(
-      probs = dat$probs,
-      reals = dat$reals,
-      output_file = output_file,
-      output_dir = output_dir,
-      renderer = "browser"
+      probs = list(example_dat$estimated_probabilities),
+      reals = list(example_dat$outcome),
+      renderer = "browser",
+      output_file = "browser_report.html",
+      output_dir = output_dir
     ),
     NA
   )
 
-  rendered_file <- file.path(output_dir, "browser.html")
+  rendered_file <- file.path(output_dir, "browser_report.html")
   expect_true(file.exists(rendered_file))
 
   html <- paste(readLines(rendered_file, warn = FALSE), collapse = "\n")
@@ -109,7 +118,52 @@ test_that("public browser renderer writes shared renderReport HTML", {
   expect_match(html, '"id":"performance-table"', fixed = TRUE)
   expect_match(html, '"id":"roc"', fixed = TRUE)
   expect_match(html, '"id":"calibration"', fixed = TRUE)
-  expect_false(grepl("renderRocV2", html, fixed = TRUE))
-  expect_false(grepl("renderCalibrationV2", html, fixed = TRUE))
-  expect_false(grepl("renderPerformanceTable", html, fixed = TRUE))
+  expect_false(grepl("import { renderReport } from", html, fixed = TRUE))
+  expect_false(grepl(
+    'src="lib/rtichoke-viz-0.5.0/rtichoke-viz.js"',
+    html,
+    fixed = TRUE
+  ))
+})
+
+
+test_that("public browser report initializes from a local file", {
+  browser <- find_headless_browser()
+  skip_if(!nzchar(browser), "No headless Chromium/Chrome available")
+
+  output_dir <- tempfile("rtichoke-summary-browser-")
+  create_summary_report(
+    probs = list(example_dat$estimated_probabilities),
+    reals = list(example_dat$outcome),
+    renderer = "browser",
+    output_file = "browser_report.html",
+    output_dir = output_dir
+  )
+
+  rendered_file <- normalizePath(
+    file.path(output_dir, "browser_report.html"),
+    winslash = "/",
+    mustWork = TRUE
+  )
+  url <- paste0("file://", rendered_file)
+  dom <- system2(
+    browser,
+    args = c(
+      "--headless=new",
+      "--no-sandbox",
+      "--disable-gpu",
+      "--disable-dev-shm-usage",
+      "--virtual-time-budget=3000",
+      "--dump-dom",
+      shQuote(url)
+    ),
+    stdout = TRUE,
+    stderr = TRUE,
+    timeout = 20
+  )
+  dom <- paste(dom, collapse = "\n")
+
+  expect_match(dom, 'data-component-id="performance-table"', fixed = TRUE)
+  expect_match(dom, 'data-component-id="roc"', fixed = TRUE)
+  expect_match(dom, 'data-component-id="calibration"', fixed = TRUE)
 })


### PR DESCRIPTION
## Summary

Fix the newly public `renderer = "browser"` summary-report path when its generated HTML is opened directly as a local `file://` document.

## Root cause

PR #206 exposed the existing internal browser ReportSpec helper publicly. The helper generated an inline ES-module initializer that imported `renderReport()` from `./lib/rtichoke-viz-0.5.0/rtichoke-viz.js`. Directly opening the saved HTML relies on a cross-file module load from a local `file://` origin, so the initializer can be blocked before `renderReport()` runs. The empty report container then remains blank.

This is a consumer integration bug, not a `rtichoke_viz v0.5.0` renderer or ReportSpec bug. The internal report helper had the same local-file problem.

## Fix

Keep the immutable v0.5.0 bundle unchanged, but inline its exact packaged JavaScript bytes into the generated module and invoke `renderReport(spec)` in that same module. CSS remains an htmltools dependency. This removes the local cross-file module import while preserving:

`statistics -> canonical standalone specs -> ReportSpec -> shared renderReport()`

No R-side component dispatcher or statistical changes are introduced.

## Regression coverage

- exercises the exact public `create_summary_report(..., renderer = "browser")` call with `example_dat`;
- asserts the saved report no longer contains a local-file `renderReport` module import;
- retains ReportSpec/component identity coverage;
- adds a headless Chromium/Chrome `file://` smoke test when a browser is available, requiring populated PerformanceTable, ROC, and calibration report component DOM.

## Scope

No changes to `rtichoke_viz`, vendored v0.5.0 assets, default RMarkdown summary reports, statistics, Plotly/ggplot2 paths, tables, or public defaults.

Do not merge automatically.