### PR TITLE
Add Quarto browser summary report acceptance proof

### DIFF
--- a/.github/workflows/quarto-browser-summary-acceptance.yaml
+++ b/.github/workflows/quarto-browser-summary-acceptance.yaml
@@ -1,0 +1,110 @@
+name: Quarto browser summary acceptance
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'R/**'
+      - 'inst/**'
+      - 'tests/integration/**'
+      - '.github/workflows/quarto-browser-summary-acceptance.yaml'
+      - 'DESCRIPTION'
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  quarto-browser-summary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          needs: check
+          pak-version: stable
+
+      - uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name: Record host versions
+        run: |
+          quarto --version
+          google-chrome --version
+
+      - name: Generate real public browser reports
+        shell: Rscript {0}
+        run: |
+          library(rtichoke)
+          out <- file.path("tests", "integration")
+          create_summary_report(
+            probs = list(example_dat$estimated_probabilities),
+            reals = list(example_dat$outcome),
+            renderer = "browser",
+            output_file = "summary-report-one.html",
+            output_dir = out
+          )
+          create_summary_report(
+            probs = list("Model B" = rev(example_dat$estimated_probabilities)),
+            reals = list(example_dat$outcome),
+            renderer = "browser",
+            output_file = "summary-report-two.html",
+            output_dir = out
+          )
+
+      - name: Render Quarto hosts
+        run: |
+          quarto render tests/integration/quarto-browser-summary-single.qmd
+          quarto render tests/integration/quarto-browser-summary.qmd
+          test -f tests/integration/quarto-browser-summary-single.html
+          test -f tests/integration/quarto-browser-summary.html
+          test -f tests/integration/summary-report-one.html
+          test -f tests/integration/summary-report-two.html
+          test -f tests/integration/lib/rtichoke-viz-0.5.0/rtichoke-viz.css
+
+      - name: Execute Quarto hosts in real Chrome
+        run: |
+          python3 -m http.server 8765 --directory tests/integration > /tmp/rtichoke-http.log 2>&1 &
+          server_pid=$!
+          trap 'kill $server_pid || true' EXIT
+          sleep 1
+
+          run_browser() {
+            name="$1"
+            url="$2"
+            stderr="/tmp/${name}-chrome-stderr.log"
+            dom="/tmp/${name}-dom.html"
+            set +e
+            google-chrome \
+              --headless=new \
+              --no-sandbox \
+              --disable-gpu \
+              --disable-dev-shm-usage \
+              --virtual-time-budget=5000 \
+              --dump-dom \
+              "$url" > "$dom" 2> "$stderr"
+            status=$?
+            set -e
+            cat "$stderr"
+            test "$status" -eq 0
+            ! grep -E 'ERROR:CONSOLE|Uncaught|Invalid ReportSpec|ReferenceError|TypeError|SyntaxError' "$stderr"
+            grep -q 'id="acceptance-status" data-ready="true"' "$dom"
+          }
+
+          run_browser single http://127.0.0.1:8765/quarto-browser-summary-single.html
+          run_browser double http://127.0.0.1:8765/quarto-browser-summary.html

--- a/tests/integration/quarto-browser-summary-single.qmd
+++ b/tests/integration/quarto-browser-summary-single.qmd
@@ -1,0 +1,42 @@
+---
+title: "rtichoke single browser summary report acceptance"
+format:
+  html:
+    embed-resources: false
+---
+
+<iframe id="report-one" src="summary-report-one.html" style="width:100%;height:1800px;border:0"></iframe>
+<div id="acceptance-status" data-ready="false"></div>
+
+<script>
+(() => {
+  const status = document.querySelector("#acceptance-status");
+  const frame = document.querySelector("#report-one");
+
+  function poll() {
+    const doc = frame.contentDocument;
+    if (doc) {
+      const component = id => doc.querySelector(`[data-component-id="${id}"]`);
+      const table = component("performance-table")?.querySelector("table.rtichoke-performance-table__table");
+      const roc = component("roc")?.querySelector("svg");
+      const calibration = component("calibration")?.querySelector("svg");
+      const report = doc.querySelector(".rtichoke-viz-report");
+      const cssLoaded = Array.from(doc.styleSheets).some(sheet =>
+        (sheet.href || "").includes("rtichoke-viz-0.5.0/rtichoke-viz.css")
+      );
+      const styled = report && getComputedStyle(report).display !== "none";
+      if (table && roc && calibration && cssLoaded && styled) {
+        status.dataset.ready = "true";
+        status.dataset.table = "true";
+        status.dataset.roc = "true";
+        status.dataset.calibration = "true";
+        status.dataset.css = "true";
+        return;
+      }
+    }
+    setTimeout(poll, 100);
+  }
+
+  poll();
+})();
+</script>

--- a/tests/integration/quarto-browser-summary.qmd
+++ b/tests/integration/quarto-browser-summary.qmd
@@ -1,0 +1,48 @@
+---
+title: "rtichoke browser summary report acceptance"
+format:
+  html:
+    embed-resources: false
+---
+
+<div id="quarto-report-host">
+  <iframe id="report-one" src="summary-report-one.html" style="width:100%;height:1800px;border:0"></iframe>
+  <iframe id="report-two" src="summary-report-two.html" style="width:100%;height:1800px;border:0"></iframe>
+</div>
+
+<div id="acceptance-status" data-ready="false"></div>
+
+<script>
+(() => {
+  const status = document.querySelector("#acceptance-status");
+  const ids = ["report-one", "report-two"];
+
+  function inspect(frame) {
+    const doc = frame.contentDocument;
+    if (!doc) return null;
+    const component = id => doc.querySelector(`[data-component-id="${id}"]`);
+    const table = component("performance-table")?.querySelector("table.rtichoke-performance-table__table");
+    const roc = component("roc")?.querySelector("svg");
+    const calibration = component("calibration")?.querySelector("svg");
+    const report = doc.querySelector(".rtichoke-viz-report");
+    const cssLoaded = Array.from(doc.styleSheets).some(sheet =>
+      (sheet.href || "").includes("rtichoke-viz-0.5.0/rtichoke-viz.css")
+    );
+    const styled = report && getComputedStyle(report).display !== "none";
+    return { table: !!table, roc: !!roc, calibration: !!calibration, cssLoaded, styled };
+  }
+
+  function poll() {
+    const results = ids.map(id => inspect(document.getElementById(id)));
+    if (results.every(result => result && Object.values(result).every(Boolean))) {
+      status.dataset.ready = "true";
+      status.dataset.reportOne = JSON.stringify(results[0]);
+      status.dataset.reportTwo = JSON.stringify(results[1]);
+      return;
+    }
+    setTimeout(poll, 100);
+  }
+
+  poll();
+})();
+</script>


### PR DESCRIPTION
## Summary

Adds dedicated, test-only Quarto/Chrome acceptance coverage for the public canonical browser summary report.

- keeps production code unchanged;
- keeps Quarto out of `Imports`/`Suggests` and normal R CMD check;
- generates reports through the real public `create_summary_report(..., renderer = "browser")` path;
- renders minimal Quarto HTML hosts using iframe/document embedding;
- checks one embedded report and two coexisting embedded reports in real headless Chrome;
- requires populated PerformanceTable, ROC SVG, calibration SVG, loaded rtichoke-viz CSS, and no meaningful browser console/runtime errors.

This intentionally does not add htmlwidgets, same-DOM fragment embedding, or any new report-host abstraction.