### PR TITLE
Add static Precision-Recall browser rendering

### DIFF
--- a/.github/workflows/precision-recall-browser-acceptance.yaml
+++ b/.github/workflows/precision-recall-browser-acceptance.yaml
@@ -1,0 +1,88 @@
+name: Precision-Recall browser acceptance
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'R/precision_recall.R'
+      - 'R/rtichoke_viz_v2.R'
+      - 'inst/**'
+      - 'tests/testthat/test-precision-recall-browser-v2.R'
+      - '.github/workflows/precision-recall-browser-acceptance.yaml'
+      - 'DESCRIPTION'
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  precision-recall-browser:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: release
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          needs: check
+          pak-version: stable
+
+      - name: Install package
+        run: R CMD INSTALL .
+
+      - name: Record browser version
+        run: google-chrome --version
+
+      - name: Generate real public Precision-Recall browser artifact
+        shell: Rscript {0}
+        run: |
+          library(rtichoke)
+
+          widget <- create_precision_recall_curve(
+            probs = list("Model A" = c(0.05, 0.2, 0.7, 0.95)),
+            reals = list("Population A" = c(0, 0, 1, 1)),
+            by = 0.25,
+            renderer = "browser"
+          )
+
+          dir.create("browser-acceptance", showWarnings = FALSE)
+          htmltools::save_html(
+            widget,
+            file = "browser-acceptance/precision-recall.html",
+            libdir = "lib"
+          )
+
+      - name: Execute direct file artifact in real Chrome
+        run: |
+          artifact="$(pwd)/browser-acceptance/precision-recall.html"
+          stderr="/tmp/precision-recall-chrome-stderr.log"
+          dom="/tmp/precision-recall-dom.html"
+
+          set +e
+          google-chrome \
+            --headless=new \
+            --no-sandbox \
+            --disable-gpu \
+            --disable-dev-shm-usage \
+            --virtual-time-budget=5000 \
+            --dump-dom \
+            "file://${artifact}" > "$dom" 2> "$stderr"
+          status=$?
+          set -e
+
+          cat "$stderr"
+          test "$status" -eq 0
+          ! grep -E 'ERROR:CONSOLE|Uncaught|ReferenceError|TypeError|SyntaxError' "$stderr"
+          grep -q '"type":"precision_recall"' "$dom"
+          grep -q '<svg' "$dom"

--- a/.github/workflows/precision-recall-browser-acceptance.yaml
+++ b/.github/workflows/precision-recall-browser-acceptance.yaml
@@ -63,9 +63,13 @@ jobs:
             libdir = "lib"
           )
 
-      - name: Execute direct file artifact in real Chrome
+      - name: Execute browser artifact in real Chrome
         run: |
-          artifact="$(pwd)/browser-acceptance/precision-recall.html"
+          python3 -m http.server 8766 --directory browser-acceptance > /tmp/rtichoke-pr-http.log 2>&1 &
+          server_pid=$!
+          trap 'kill $server_pid || true' EXIT
+          sleep 1
+
           stderr="/tmp/precision-recall-chrome-stderr.log"
           dom="/tmp/precision-recall-dom.html"
 
@@ -77,7 +81,7 @@ jobs:
             --disable-dev-shm-usage \
             --virtual-time-budget=5000 \
             --dump-dom \
-            "file://${artifact}" > "$dom" 2> "$stderr"
+            "http://127.0.0.1:8766/precision-recall.html" > "$dom" 2> "$stderr"
           status=$?
           set -e
 

--- a/R/precision_recall.R
+++ b/R/precision_recall.R
@@ -103,20 +103,27 @@ create_precision_recall_curve <- function(
     "#D1603D",
     "#585123"
   ),
-  size = NULL
+  size = NULL,
+  renderer = "default"
 ) {
-  prepare_performance_data(
+  performance_data <- prepare_performance_data(
     probs = probs,
     reals = reals,
     by = by,
     stratified_by = stratified_by
-  ) |>
-    plot_precision_recall_curve(
-      chosen_threshold = chosen_threshold,
-      interactive = interactive,
-      color_values = color_values,
-      size = size
-    )
+  )
+  evaluation_metadata <- if (identical(renderer, "browser")) {
+    build_evaluation_metadata(probs, reals)
+  }
+  plot_precision_recall_curve(
+    performance_data,
+    chosen_threshold = chosen_threshold,
+    interactive = interactive,
+    color_values = color_values,
+    size = size,
+    renderer = renderer,
+    evaluation_metadata = evaluation_metadata
+  )
 }
 
 
@@ -176,8 +183,26 @@ plot_precision_recall_curve <- function(
     "#D1603D",
     "#585123"
   ),
-  size = NULL
+  size = NULL,
+  renderer = "default",
+  evaluation_metadata = NULL
 ) {
+  renderer <- rtichoke_viz_renderer(renderer, interactive)
+  if (renderer == "browser") {
+    if (is.null(evaluation_metadata)) {
+      stop(
+        "Browser rendering requires explicit evaluation_metadata",
+        call. = FALSE
+      )
+    }
+    return(render_rtichoke_viz_browser(
+      rtichoke_viz_precision_recall_v2_spec(
+        performance_data,
+        evaluation_metadata
+      )
+    ))
+  }
+
   rtichoke_curve_list <- performance_data |>
     create_rtichoke_curve_list(
       "precision recall",
@@ -191,7 +216,7 @@ plot_precision_recall_curve <- function(
     perf_dat_type
   )
 
-  if (interactive == FALSE) {
+  if (renderer == "ggplot2") {
     reference_lines <- create_reference_lines_data_frame(
       "precision recall",
       prevalence
@@ -209,7 +234,7 @@ plot_precision_recall_curve <- function(
       ggplot2::ylab("PPV")
   }
 
-  if (interactive == TRUE) {
+  if (renderer == "plotly") {
     precision_recall_curve <- rtichoke_curve_list |>
       create_plotly_curve()
   }

--- a/R/rtichoke_viz_v2.R
+++ b/R/rtichoke_viz_v2.R
@@ -43,6 +43,7 @@ rtichoke_viz_browser_id <- local({
 render_rtichoke_viz_browser <- function(spec) {
   renderers <- c(
     roc = "renderRocV2",
+    precision_recall = "renderPrecisionRecallV2",
     gains = "renderGainsV2",
     lift = "renderLiftV2"
   )
@@ -232,6 +233,51 @@ rtichoke_viz_gains_v2_spec <- function(
   spec
 }
 
+#' Build a canonical rtichoke_viz v2 Precision-Recall specification
+#'
+#' Translate already-computed Precision-Recall performance data plus explicit
+#' semantic evaluation metadata into the canonical rtichoke_viz v2 contract.
+#' Population prevalence references are derived from the same production
+#' prevalence helper used by the existing canonical curve builders.
+#'
+#' @inheritParams rtichoke_viz_roc_v2_spec
+#'
+#' @return A nested list representing a canonical Precision-Recall v2
+#'   specification.
+#' @noRd
+rtichoke_viz_precision_recall_v2_spec <- function(
+  performance_data,
+  evaluation_metadata
+) {
+  spec <- rtichoke_viz_curve_v2_spec(
+    performance_data,
+    evaluation_metadata,
+    type = "precision_recall"
+  )
+
+  populations <- unique(vapply(
+    spec$evaluations,
+    `[[`,
+    character(1),
+    "population"
+  ))
+  prevalence <- v2_population_prevalence(
+    performance_data,
+    evaluation_metadata,
+    populations
+  )
+
+  spec$references <- lapply(populations, function(population) {
+    list(
+      type = "horizontal",
+      scope = "population",
+      population = population,
+      value = as.numeric(prevalence[[population]])
+    )
+  })
+  spec
+}
+
 v2_population_prevalence <- function(
   performance_data,
   evaluation_metadata,
@@ -284,12 +330,13 @@ gains_v2_population_prevalence <- v2_population_prevalence
 rtichoke_viz_curve_v2_spec <- function(
   performance_data,
   evaluation_metadata,
-  type = c("roc", "gains", "lift")
+  type = c("roc", "precision_recall", "gains", "lift")
 ) {
   type <- match.arg(type)
   required_columns <- switch(
     type,
     roc = c("probability_threshold", "sensitivity", "specificity"),
+    precision_recall = c("probability_threshold", "sensitivity", "PPV"),
     gains = c("probability_threshold", "ppcr", "sensitivity"),
     lift = c("probability_threshold", "ppcr", "lift")
   )
@@ -399,6 +446,9 @@ rtichoke_viz_curve_v2_spec <- function(
     if (type == "roc") {
       datum$sensitivity <- as.numeric(performance_data$sensitivity[[i]])
       datum$specificity <- as.numeric(performance_data$specificity[[i]])
+    } else if (type == "precision_recall") {
+      datum$sensitivity <- as.numeric(performance_data$sensitivity[[i]])
+      datum$ppv <- as.numeric(performance_data$PPV[[i]])
     } else if (type == "gains") {
       datum$sensitivity <- as.numeric(performance_data$sensitivity[[i]])
       datum$ppcr <- as.numeric(performance_data$ppcr[[i]])
@@ -421,6 +471,21 @@ rtichoke_viz_curve_v2_spec <- function(
       xAxis = list(label = "1 - Specificity", domain = c(0, 1)),
       yAxis = list(label = "Sensitivity", domain = c(0, 1)),
       references = list(list(type = "identity", scope = "global"))
+    ))
+  }
+
+  if (type == "precision_recall") {
+    return(list(
+      schemaVersion = "2.0",
+      type = "precision_recall",
+      evaluations = evaluations,
+      series = series,
+      data = data,
+      x = "sensitivity",
+      y = "ppv",
+      xAxis = list(label = "Sensitivity", domain = c(0, 1)),
+      yAxis = list(label = "PPV", domain = c(0, 1)),
+      references = list()
     ))
   }
 

--- a/R/rtichoke_viz_v2.R
+++ b/R/rtichoke_viz_v2.R
@@ -249,6 +249,11 @@ rtichoke_viz_precision_recall_v2_spec <- function(
   performance_data,
   evaluation_metadata
 ) {
+  valid_rows <- is.finite(as.numeric(performance_data$probability_threshold)) &
+    is.finite(as.numeric(performance_data$sensitivity)) &
+    is.finite(as.numeric(performance_data$PPV))
+  performance_data <- performance_data[valid_rows, , drop = FALSE]
+
   spec <- rtichoke_viz_curve_v2_spec(
     performance_data,
     evaluation_metadata,

--- a/man/create_precision_recall_curve.Rd
+++ b/man/create_precision_recall_curve.Rd
@@ -38,9 +38,8 @@ plots}
 
 \item{size}{the size of the curve}
 
-\item{renderer}{rendering backend. \code{"default"} preserves the existing
-\code{interactive} behavior; alternatives are \code{"ggplot2"}, \code{"plotly"}, and
-\code{"browser"}.}
+\item{renderer}{rendering backend. The default preserves the historical
+interactive behavior; alternatives are "ggplot2", "plotly", and "browser".}
 }
 \description{
 Create a Precision Recall Curve

--- a/man/create_precision_recall_curve.Rd
+++ b/man/create_precision_recall_curve.Rd
@@ -38,8 +38,9 @@ plots}
 
 \item{size}{the size of the curve}
 
-\item{renderer}{rendering backend. The default preserves the historical
-interactive behavior; alternatives are "ggplot2", "plotly", and "browser".}
+\item{renderer}{rendering backend. \code{"default"} preserves the existing
+\code{interactive} behavior; alternatives are \code{"ggplot2"}, \code{"plotly"}, and
+\code{"browser"}.}
 }
 \description{
 Create a Precision Recall Curve

--- a/man/create_precision_recall_curve.Rd
+++ b/man/create_precision_recall_curve.Rd
@@ -14,7 +14,8 @@ create_precision_recall_curve(
   color_values = c("#1b9e77", "#d95f02", "#7570b3", "#e7298a", "#07004D", "#E6AB02",
     "#FE5F55", "#54494B", "#006E90", "#BC96E6", "#52050A", "#1F271B", "#BE7C4D",
     "#63768D", "#08A045", "#320A28", "#82FF9E", "#2176FF", "#D1603D", "#585123"),
-  size = NULL
+  size = NULL,
+  renderer = "default"
 )
 }
 \arguments{
@@ -36,6 +37,10 @@ plots}
 \item{color_values}{color palette}
 
 \item{size}{the size of the curve}
+
+\item{renderer}{rendering backend. \code{"default"} preserves the existing
+\code{interactive} behavior; alternatives are \code{"ggplot2"}, \code{"plotly"}, and
+\code{"browser"}.}
 }
 \description{
 Create a Precision Recall Curve

--- a/man/plot_precision_recall_curve.Rd
+++ b/man/plot_precision_recall_curve.Rd
@@ -28,13 +28,11 @@ plots}
 
 \item{size}{the size of the curve}
 
-\item{renderer}{rendering backend. \code{"default"} preserves the existing
-\code{interactive} behavior; alternatives are \code{"ggplot2"}, \code{"plotly"}, and
-\code{"browser"}.}
+\item{renderer}{rendering backend. The default preserves the historical
+interactive behavior; alternatives are "ggplot2", "plotly", and "browser".}
 
-\item{evaluation_metadata}{explicit semantic evaluation metadata required
-when \code{renderer = "browser"}. It is supplied automatically by
-\code{create_roc_curve()}.}
+\item{evaluation_metadata}{explicit semantic evaluation metadata. Required for
+precomputed data when \code{renderer = "browser"}.}
 }
 \description{
 Plot a Precision Recall Curve

--- a/man/plot_precision_recall_curve.Rd
+++ b/man/plot_precision_recall_curve.Rd
@@ -11,7 +11,9 @@ plot_precision_recall_curve(
   color_values = c("#1b9e77", "#d95f02", "#7570b3", "#e7298a", "#07004D", "#E6AB02",
     "#FE5F55", "#54494B", "#006E90", "#BC96E6", "#52050A", "#1F271B", "#BE7C4D",
     "#63768D", "#08A045", "#320A28", "#82FF9E", "#2176FF", "#D1603D", "#585123"),
-  size = NULL
+  size = NULL,
+  renderer = "default",
+  evaluation_metadata = NULL
 )
 }
 \arguments{
@@ -25,6 +27,14 @@ plots}
 \item{color_values}{color palette}
 
 \item{size}{the size of the curve}
+
+\item{renderer}{rendering backend. \code{"default"} preserves the existing
+\code{interactive} behavior; alternatives are \code{"ggplot2"}, \code{"plotly"}, and
+\code{"browser"}.}
+
+\item{evaluation_metadata}{explicit semantic evaluation metadata required
+when \code{renderer = "browser"}. It is supplied automatically by
+\code{create_roc_curve()}.}
 }
 \description{
 Plot a Precision Recall Curve

--- a/man/plot_precision_recall_curve.Rd
+++ b/man/plot_precision_recall_curve.Rd
@@ -28,11 +28,13 @@ plots}
 
 \item{size}{the size of the curve}
 
-\item{renderer}{rendering backend. The default preserves the historical
-interactive behavior; alternatives are "ggplot2", "plotly", and "browser".}
+\item{renderer}{rendering backend. \code{"default"} preserves the existing
+\code{interactive} behavior; alternatives are \code{"ggplot2"}, \code{"plotly"}, and
+\code{"browser"}.}
 
-\item{evaluation_metadata}{explicit semantic evaluation metadata. Required for
-precomputed data when \code{renderer = "browser"}.}
+\item{evaluation_metadata}{explicit semantic evaluation metadata required
+when \code{renderer = "browser"}. It is supplied automatically by
+\code{\link[=create_roc_curve]{create_roc_curve()}}.}
 }
 \description{
 Plot a Precision Recall Curve

--- a/tests/testthat/test-precision-recall-browser-v2.R
+++ b/tests/testthat/test-precision-recall-browser-v2.R
@@ -59,7 +59,12 @@ test_that("Precision-Recall v2 is a pure adapter over existing performance rows"
   )
   expect_true(all(vapply(
     spec$data,
-    function(x) identical(names(x), c("seriesId", "cutoff", "sensitivity", "ppv")),
+    function(x) {
+      identical(
+        names(x),
+        c("seriesId", "cutoff", "sensitivity", "ppv")
+      )
+    },
     logical(1)
   )))
 })
@@ -84,7 +89,11 @@ test_that("Precision-Recall v2 represents one model in one population", {
     list(list(
       id = "series-1",
       evaluationId = "evaluation-1",
-      display = list(label = "Model A", group = "Model A", role = "model")
+      display = list(
+        label = "Model A",
+        group = "Model A",
+        role = "model"
+      )
     ))
   )
   expect_identical(
@@ -126,74 +135,91 @@ test_that("Precision-Recall v2 shares one prevalence reference across models", {
   expect_identical(spec$references[[1]]$value, 0.5)
 })
 
-test_that("Precision-Recall v2 preserves population-shaped model-unknown semantics", {
-  probs <- list(
-    "Population A" = c(0.05, 0.2, 0.7, 0.95),
-    "Population B" = c(0.1, 0.4, 0.6, 0.9)
-  )
-  reals <- list(
-    "Population A" = c(0, 0, 0, 1),
-    "Population B" = c(0, 0, 1, 1)
-  )
-  spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
-    prepare_performance_data(probs, reals, by = 0.25),
-    rtichoke:::build_evaluation_metadata(probs, reals)
-  )
-
-  expect_identical(
-    spec$evaluations,
-    list(
-      list(id = "evaluation-1", population = "Population A"),
-      list(id = "evaluation-2", population = "Population B")
+test_that(
+  "Precision-Recall v2 preserves population-shaped model-unknown semantics",
+  {
+    probs <- list(
+      "Population A" = c(0.05, 0.2, 0.7, 0.95),
+      "Population B" = c(0.1, 0.4, 0.6, 0.9)
     )
-  )
-  expect_false(any(vapply(
-    spec$evaluations,
-    function(x) "model" %in% names(x),
-    logical(1)
-  )))
-  expect_identical(
-    lapply(spec$series, `[[`, "display"),
-    list(
-      list(label = "Population A", group = "Population A", role = "population"),
-      list(label = "Population B", group = "Population B", role = "population")
+    reals <- list(
+      "Population A" = c(0, 0, 0, 1),
+      "Population B" = c(0, 0, 1, 1)
     )
-  )
-  expect_identical(
-    vapply(spec$references, `[[`, character(1), "population"),
-    c("Population A", "Population B")
-  )
-  expect_identical(
-    vapply(spec$references, `[[`, numeric(1), "value"),
-    c(0.25, 0.5)
-  )
-})
+    spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
+      prepare_performance_data(probs, reals, by = 0.25),
+      rtichoke:::build_evaluation_metadata(probs, reals)
+    )
 
-test_that("Precision-Recall v2 keeps equal-prevalence populations as distinct owners", {
-  probs <- list(
-    "Population A" = c(0.05, 0.2, 0.7, 0.95),
-    "Population B" = c(0.1, 0.4, 0.6, 0.9)
-  )
-  reals <- list(
-    "Population A" = c(0, 0, 1, 1),
-    "Population B" = c(0, 1, 0, 1)
-  )
-  spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
-    prepare_performance_data(probs, reals, by = 0.25),
-    rtichoke:::build_evaluation_metadata(probs, reals)
-  )
+    expect_identical(
+      spec$evaluations,
+      list(
+        list(id = "evaluation-1", population = "Population A"),
+        list(id = "evaluation-2", population = "Population B")
+      )
+    )
+    expect_false(any(vapply(
+      spec$evaluations,
+      function(x) "model" %in% names(x),
+      logical(1)
+    )))
+    expect_identical(
+      lapply(spec$series, `[[`, "display"),
+      list(
+        list(
+          label = "Population A",
+          group = "Population A",
+          role = "population"
+        ),
+        list(
+          label = "Population B",
+          group = "Population B",
+          role = "population"
+        )
+      )
+    )
+    expect_identical(
+      vapply(spec$references, `[[`, character(1), "population"),
+      c("Population A", "Population B")
+    )
+    expect_identical(
+      vapply(spec$references, `[[`, numeric(1), "value"),
+      c(0.25, 0.5)
+    )
+  }
+)
 
-  expect_length(spec$references, 2)
-  expect_identical(
-    vapply(spec$references, `[[`, character(1), "population"),
-    c("Population A", "Population B")
-  )
-  expect_identical(
-    vapply(spec$references, `[[`, numeric(1), "value"),
-    c(0.5, 0.5)
-  )
-  expect_false(identical(spec$references[[1]]$population, spec$references[[2]]$population))
-})
+test_that(
+  "Precision-Recall v2 keeps equal-prevalence populations as distinct owners",
+  {
+    probs <- list(
+      "Population A" = c(0.05, 0.2, 0.7, 0.95),
+      "Population B" = c(0.1, 0.4, 0.6, 0.9)
+    )
+    reals <- list(
+      "Population A" = c(0, 0, 1, 1),
+      "Population B" = c(0, 1, 0, 1)
+    )
+    spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
+      prepare_performance_data(probs, reals, by = 0.25),
+      rtichoke:::build_evaluation_metadata(probs, reals)
+    )
+
+    expect_length(spec$references, 2)
+    expect_identical(
+      vapply(spec$references, `[[`, character(1), "population"),
+      c("Population A", "Population B")
+    )
+    expect_identical(
+      vapply(spec$references, `[[`, numeric(1), "value"),
+      c(0.5, 0.5)
+    )
+    expect_false(identical(
+      spec$references[[1]]$population,
+      spec$references[[2]]$population
+    ))
+  }
+)
 
 test_that("Precision-Recall v2 IDs are deterministic and label-independent", {
   probs <- list(
@@ -282,7 +308,11 @@ test_that("Precision-Recall browser dispatch uses the canonical shared renderer"
     renderer = "browser",
     evaluation_metadata = dat$metadata
   )
-  expect_match(as.character(precomputed), "renderPrecisionRecallV2", fixed = TRUE)
+  expect_match(
+    as.character(precomputed),
+    "renderPrecisionRecallV2",
+    fixed = TRUE
+  )
   expect_error(
     plot_precision_recall_curve(dat$performance_data, renderer = "browser"),
     "explicit evaluation_metadata"
@@ -306,7 +336,11 @@ test_that("public Precision-Recall browser artifact renders SVG from file", {
   output_file <- file.path(output_dir, "precision-recall.html")
   htmltools::save_html(widget, output_file, libdir = "lib")
 
-  rendered_file <- normalizePath(output_file, winslash = "/", mustWork = TRUE)
+  rendered_file <- normalizePath(
+    output_file,
+    winslash = "/",
+    mustWork = TRUE
+  )
   stderr_file <- tempfile("rtichoke-pr-browser-stderr-")
   dom_lines <- system2(
     browser_bin,
@@ -325,7 +359,10 @@ test_that("public Precision-Recall browser artifact renders SVG from file", {
   )
   status <- attr(dom_lines, "status")
   dom <- paste(dom_lines, collapse = "\n")
-  browser_stderr <- paste(readLines(stderr_file, warn = FALSE), collapse = "\n")
+  browser_stderr <- paste(
+    readLines(stderr_file, warn = FALSE),
+    collapse = "\n"
+  )
 
   expect_null(status, info = browser_stderr)
   expect_false(

--- a/tests/testthat/test-precision-recall-browser-v2.R
+++ b/tests/testthat/test-precision-recall-browser-v2.R
@@ -9,31 +9,6 @@ precision_recall_v2_fixture <- function() {
   )
 }
 
-precision_recall_headless_browser <- function() {
-  candidates <- Sys.which(c(
-    "chromium",
-    "chromium-browser",
-    "google-chrome",
-    "google-chrome-stable"
-  ))
-  candidates <- unname(candidates[nzchar(candidates)])
-  for (candidate in candidates) {
-    res <- tryCatch(
-      suppressWarnings(system2(
-        candidate,
-        args = "--version",
-        stdout = FALSE,
-        stderr = FALSE
-      )),
-      error = function(...) 1L
-    )
-    if (identical(res, 0L)) {
-      return(candidate)
-    }
-  }
-  ""
-}
-
 test_that("Precision-Recall v2 is a pure adapter over existing performance rows", {
   dat <- precision_recall_v2_fixture()
   spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
@@ -213,10 +188,12 @@ test_that("Precision-Recall v2 keeps equal-prevalence populations as distinct ow
     vapply(spec$references, `[[`, numeric(1), "value"),
     c(0.5, 0.5)
   )
-  expect_false(identical(
-    spec$references[[1]]$population,
-    spec$references[[2]]$population
-  ))
+  expect_false(
+    identical(
+      spec$references[[1]]$population,
+      spec$references[[2]]$population
+    )
+  )
 })
 
 test_that("Precision-Recall v2 IDs are deterministic and label-independent", {
@@ -318,60 +295,4 @@ test_that("Precision-Recall browser dispatch uses the canonical shared renderer"
     plot_precision_recall_curve(dat$performance_data, renderer = "browser"),
     "explicit evaluation_metadata"
   )
-})
-
-test_that("public Precision-Recall browser artifact renders SVG from file", {
-  skip_on_os("windows")
-  browser <- precision_recall_headless_browser()
-  skip_if(!nzchar(browser), "No headless Chromium/Chrome available")
-
-  dat <- precision_recall_v2_fixture()
-  widget <- create_precision_recall_curve(
-    dat$probs,
-    dat$reals,
-    by = 0.25,
-    renderer = "browser"
-  )
-  output_dir <- tempfile("rtichoke-pr-browser-")
-  dir.create(output_dir, recursive = TRUE)
-  output_file <- file.path(output_dir, "precision-recall.html")
-  htmltools::save_html(widget, output_file, libdir = "lib")
-
-  rendered_file <- normalizePath(
-    output_file,
-    winslash = "/",
-    mustWork = TRUE
-  )
-  url <- paste0("file://", rendered_file)
-  stderr_file <- tempfile("rtichoke-pr-browser-stderr-")
-  dom_lines <- system2(
-    browser,
-    args = c(
-      "--headless=new",
-      "--no-sandbox",
-      "--disable-gpu",
-      "--disable-dev-shm-usage",
-      "--virtual-time-budget=3000",
-      "--dump-dom",
-      shQuote(url)
-    ),
-    stdout = TRUE,
-    stderr = stderr_file,
-    timeout = 20
-  )
-  status <- attr(dom_lines, "status")
-  dom <- paste(dom_lines, collapse = "\n")
-  browser_stderr <- paste(readLines(stderr_file, warn = FALSE), collapse = "\n")
-
-  expect_null(status, info = browser_stderr)
-  expect_false(
-    grepl(
-      "ERROR:CONSOLE|Uncaught|ReferenceError|TypeError|SyntaxError",
-      browser_stderr,
-      perl = TRUE
-    ),
-    info = browser_stderr
-  )
-  expect_match(dom, '"type":"precision_recall"', fixed = TRUE)
-  expect_match(dom, "<svg", fixed = TRUE)
 })

--- a/tests/testthat/test-precision-recall-browser-v2.R
+++ b/tests/testthat/test-precision-recall-browser-v2.R
@@ -40,6 +40,9 @@ test_that("Precision-Recall v2 is a pure adapter over existing performance rows"
     dat$performance_data,
     dat$metadata
   )
+  valid <- is.finite(as.numeric(dat$performance_data$probability_threshold)) &
+    is.finite(as.numeric(dat$performance_data$sensitivity)) &
+    is.finite(as.numeric(dat$performance_data$PPV))
 
   expect_identical(spec$schemaVersion, "2.0")
   expect_identical(spec$type, "precision_recall")
@@ -47,16 +50,21 @@ test_that("Precision-Recall v2 is a pure adapter over existing performance rows"
   expect_identical(spec$y, "ppv")
   expect_identical(
     vapply(spec$data, `[[`, numeric(1), "cutoff"),
-    as.numeric(dat$performance_data$probability_threshold)
+    as.numeric(dat$performance_data$probability_threshold[valid])
   )
   expect_identical(
     vapply(spec$data, `[[`, numeric(1), "sensitivity"),
-    as.numeric(dat$performance_data$sensitivity)
+    as.numeric(dat$performance_data$sensitivity[valid])
   )
   expect_identical(
     vapply(spec$data, `[[`, numeric(1), "ppv"),
-    as.numeric(dat$performance_data$PPV)
+    as.numeric(dat$performance_data$PPV[valid])
   )
+  expect_true(all(vapply(
+    spec$data,
+    function(x) all(is.finite(c(x$cutoff, x$sensitivity, x$ppv))),
+    logical(1)
+  )))
   expect_true(all(
     c("seriesId", "cutoff", "sensitivity", "ppv") %in% names(spec$data[[1]])
   ))

--- a/tests/testthat/test-precision-recall-browser-v2.R
+++ b/tests/testthat/test-precision-recall-browser-v2.R
@@ -1,0 +1,341 @@
+precision_recall_v2_fixture <- function() {
+  probs <- list("Model A" = c(0.05, 0.2, 0.7, 0.95))
+  reals <- list("Population A" = c(0, 0, 1, 1))
+  list(
+    probs = probs,
+    reals = reals,
+    performance_data = prepare_performance_data(probs, reals, by = 0.25),
+    metadata = rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+}
+
+precision_recall_headless_browser <- function() {
+  candidates <- Sys.which(c(
+    "chromium",
+    "chromium-browser",
+    "google-chrome",
+    "google-chrome-stable"
+  ))
+  candidates <- unname(candidates[nzchar(candidates)])
+  for (candidate in candidates) {
+    status <- tryCatch(
+      suppressWarnings(system2(
+        candidate,
+        args = "--version",
+        stdout = FALSE,
+        stderr = FALSE
+      )),
+      error = function(...) 1L
+    )
+    if (identical(status, 0L)) {
+      return(candidate)
+    }
+  }
+  ""
+}
+
+test_that("Precision-Recall v2 is a pure adapter over existing performance rows", {
+  dat <- precision_recall_v2_fixture()
+  spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
+    dat$performance_data,
+    dat$metadata
+  )
+
+  expect_identical(spec$schemaVersion, "2.0")
+  expect_identical(spec$type, "precision_recall")
+  expect_identical(spec$x, "sensitivity")
+  expect_identical(spec$y, "ppv")
+  expect_identical(
+    vapply(spec$data, `[[`, numeric(1), "cutoff"),
+    as.numeric(dat$performance_data$probability_threshold)
+  )
+  expect_identical(
+    vapply(spec$data, `[[`, numeric(1), "sensitivity"),
+    as.numeric(dat$performance_data$sensitivity)
+  )
+  expect_identical(
+    vapply(spec$data, `[[`, numeric(1), "ppv"),
+    as.numeric(dat$performance_data$PPV)
+  )
+  expect_true(all(vapply(
+    spec$data,
+    function(x) identical(names(x), c("seriesId", "cutoff", "sensitivity", "ppv")),
+    logical(1)
+  )))
+})
+
+test_that("Precision-Recall v2 represents one model in one population", {
+  dat <- precision_recall_v2_fixture()
+  spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
+    dat$performance_data,
+    dat$metadata
+  )
+
+  expect_identical(
+    spec$evaluations,
+    list(list(
+      id = "evaluation-1",
+      population = "Population A",
+      model = "Model A"
+    ))
+  )
+  expect_identical(
+    spec$series,
+    list(list(
+      id = "series-1",
+      evaluationId = "evaluation-1",
+      display = list(label = "Model A", group = "Model A", role = "model")
+    ))
+  )
+  expect_identical(
+    spec$references,
+    list(list(
+      type = "horizontal",
+      scope = "population",
+      population = "Population A",
+      value = 0.5
+    ))
+  )
+})
+
+test_that("Precision-Recall v2 shares one prevalence reference across models", {
+  probs <- list(
+    "Model A" = c(0.05, 0.2, 0.7, 0.95),
+    "Model B" = c(0.1, 0.4, 0.6, 0.9)
+  )
+  reals <- list("Population A" = c(0, 0, 1, 1))
+  spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  expect_identical(
+    vapply(spec$evaluations, `[[`, character(1), "id"),
+    c("evaluation-1", "evaluation-2")
+  )
+  expect_identical(
+    vapply(spec$series, `[[`, character(1), "id"),
+    c("series-1", "series-2")
+  )
+  expect_identical(
+    vapply(spec$evaluations, `[[`, character(1), "population"),
+    c("Population A", "Population A")
+  )
+  expect_length(spec$references, 1)
+  expect_identical(spec$references[[1]]$population, "Population A")
+  expect_identical(spec$references[[1]]$value, 0.5)
+})
+
+test_that("Precision-Recall v2 preserves population-shaped model-unknown semantics", {
+  probs <- list(
+    "Population A" = c(0.05, 0.2, 0.7, 0.95),
+    "Population B" = c(0.1, 0.4, 0.6, 0.9)
+  )
+  reals <- list(
+    "Population A" = c(0, 0, 0, 1),
+    "Population B" = c(0, 0, 1, 1)
+  )
+  spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  expect_identical(
+    spec$evaluations,
+    list(
+      list(id = "evaluation-1", population = "Population A"),
+      list(id = "evaluation-2", population = "Population B")
+    )
+  )
+  expect_false(any(vapply(
+    spec$evaluations,
+    function(x) "model" %in% names(x),
+    logical(1)
+  )))
+  expect_identical(
+    lapply(spec$series, `[[`, "display"),
+    list(
+      list(label = "Population A", group = "Population A", role = "population"),
+      list(label = "Population B", group = "Population B", role = "population")
+    )
+  )
+  expect_identical(
+    vapply(spec$references, `[[`, character(1), "population"),
+    c("Population A", "Population B")
+  )
+  expect_identical(
+    vapply(spec$references, `[[`, numeric(1), "value"),
+    c(0.25, 0.5)
+  )
+})
+
+test_that("Precision-Recall v2 keeps equal-prevalence populations as distinct owners", {
+  probs <- list(
+    "Population A" = c(0.05, 0.2, 0.7, 0.95),
+    "Population B" = c(0.1, 0.4, 0.6, 0.9)
+  )
+  reals <- list(
+    "Population A" = c(0, 0, 1, 1),
+    "Population B" = c(0, 1, 0, 1)
+  )
+  spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  expect_length(spec$references, 2)
+  expect_identical(
+    vapply(spec$references, `[[`, character(1), "population"),
+    c("Population A", "Population B")
+  )
+  expect_identical(
+    vapply(spec$references, `[[`, numeric(1), "value"),
+    c(0.5, 0.5)
+  )
+  expect_false(identical(spec$references[[1]]$population, spec$references[[2]]$population))
+})
+
+test_that("Precision-Recall v2 IDs are deterministic and label-independent", {
+  probs <- list(
+    "Population A" = c(0.05, 0.2, 0.7, 0.95),
+    "Population B" = c(0.1, 0.4, 0.6, 0.9)
+  )
+  reals <- list(
+    "Population A" = c(0, 0, 1, 1),
+    "Population B" = c(0, 1, 0, 1)
+  )
+  spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  renamed_probs <- stats::setNames(probs, c("Cohort X", "Cohort Y"))
+  renamed_reals <- stats::setNames(reals, c("Cohort X", "Cohort Y"))
+  renamed_spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
+    prepare_performance_data(renamed_probs, renamed_reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(renamed_probs, renamed_reals)
+  )
+
+  expect_identical(
+    vapply(spec$evaluations, `[[`, character(1), "id"),
+    c("evaluation-1", "evaluation-2")
+  )
+  expect_identical(
+    vapply(spec$series, `[[`, character(1), "id"),
+    c("series-1", "series-2")
+  )
+  expect_identical(
+    vapply(spec$evaluations, `[[`, character(1), "id"),
+    vapply(renamed_spec$evaluations, `[[`, character(1), "id")
+  )
+  expect_identical(
+    vapply(spec$series, `[[`, character(1), "id"),
+    vapply(renamed_spec$series, `[[`, character(1), "id")
+  )
+})
+
+test_that("Precision-Recall public renderers preserve historical defaults", {
+  dat <- precision_recall_v2_fixture()
+
+  expect_s3_class(
+    create_precision_recall_curve(dat$probs, dat$reals, by = 0.25),
+    "plotly"
+  )
+  expect_s3_class(
+    create_precision_recall_curve(
+      dat$probs,
+      dat$reals,
+      by = 0.25,
+      interactive = FALSE
+    ),
+    "ggplot"
+  )
+  expect_s3_class(
+    plot_precision_recall_curve(dat$performance_data, renderer = "plotly"),
+    "plotly"
+  )
+  expect_s3_class(
+    plot_precision_recall_curve(dat$performance_data, renderer = "ggplot2"),
+    "ggplot"
+  )
+})
+
+test_that("Precision-Recall browser dispatch uses the canonical shared renderer", {
+  dat <- precision_recall_v2_fixture()
+  browser <- create_precision_recall_curve(
+    dat$probs,
+    dat$reals,
+    by = 0.25,
+    renderer = "browser"
+  )
+  html <- as.character(browser)
+
+  expect_s3_class(browser, "shiny.tag.list")
+  expect_match(html, "renderPrecisionRecallV2", fixed = TRUE)
+  expect_match(html, '"schemaVersion":"2.0"', fixed = TRUE)
+  expect_match(html, '"type":"precision_recall"', fixed = TRUE)
+  expect_match(html, '"x":"sensitivity"', fixed = TRUE)
+  expect_match(html, '"y":"ppv"', fixed = TRUE)
+
+  precomputed <- plot_precision_recall_curve(
+    dat$performance_data,
+    renderer = "browser",
+    evaluation_metadata = dat$metadata
+  )
+  expect_match(as.character(precomputed), "renderPrecisionRecallV2", fixed = TRUE)
+  expect_error(
+    plot_precision_recall_curve(dat$performance_data, renderer = "browser"),
+    "explicit evaluation_metadata"
+  )
+})
+
+test_that("public Precision-Recall browser artifact renders SVG from file", {
+  skip_on_os("windows")
+  browser_bin <- precision_recall_headless_browser()
+  skip_if(!nzchar(browser_bin), "No headless Chromium/Chrome available")
+
+  dat <- precision_recall_v2_fixture()
+  widget <- create_precision_recall_curve(
+    dat$probs,
+    dat$reals,
+    by = 0.25,
+    renderer = "browser"
+  )
+  output_dir <- tempfile("rtichoke-pr-browser-")
+  dir.create(output_dir, recursive = TRUE)
+  output_file <- file.path(output_dir, "precision-recall.html")
+  htmltools::save_html(widget, output_file, libdir = "lib")
+
+  rendered_file <- normalizePath(output_file, winslash = "/", mustWork = TRUE)
+  stderr_file <- tempfile("rtichoke-pr-browser-stderr-")
+  dom_lines <- system2(
+    browser_bin,
+    args = c(
+      "--headless=new",
+      "--no-sandbox",
+      "--disable-gpu",
+      "--disable-dev-shm-usage",
+      "--virtual-time-budget=3000",
+      "--dump-dom",
+      shQuote(paste0("file://", rendered_file))
+    ),
+    stdout = TRUE,
+    stderr = stderr_file,
+    timeout = 20
+  )
+  status <- attr(dom_lines, "status")
+  dom <- paste(dom_lines, collapse = "\n")
+  browser_stderr <- paste(readLines(stderr_file, warn = FALSE), collapse = "\n")
+
+  expect_null(status, info = browser_stderr)
+  expect_false(
+    grepl(
+      "ERROR:CONSOLE|Uncaught|ReferenceError|TypeError|SyntaxError",
+      browser_stderr,
+      perl = TRUE
+    ),
+    info = browser_stderr
+  )
+  expect_match(dom, '"type":"precision_recall"', fixed = TRUE)
+  expect_match(dom, "<svg", fixed = TRUE)
+})

--- a/tests/testthat/test-precision-recall-browser-v2.R
+++ b/tests/testthat/test-precision-recall-browser-v2.R
@@ -18,7 +18,7 @@ precision_recall_headless_browser <- function() {
   ))
   candidates <- unname(candidates[nzchar(candidates)])
   for (candidate in candidates) {
-    status <- tryCatch(
+    res <- tryCatch(
       suppressWarnings(system2(
         candidate,
         args = "--version",
@@ -27,7 +27,7 @@ precision_recall_headless_browser <- function() {
       )),
       error = function(...) 1L
     )
-    if (identical(status, 0L)) {
+    if (identical(res, 0L)) {
       return(candidate)
     }
   }
@@ -57,16 +57,9 @@ test_that("Precision-Recall v2 is a pure adapter over existing performance rows"
     vapply(spec$data, `[[`, numeric(1), "ppv"),
     as.numeric(dat$performance_data$PPV)
   )
-  expect_true(all(vapply(
-    spec$data,
-    function(x) {
-      identical(
-        names(x),
-        c("seriesId", "cutoff", "sensitivity", "ppv")
-      )
-    },
-    logical(1)
-  )))
+  expect_true(all(
+    c("seriesId", "cutoff", "sensitivity", "ppv") %in% names(spec$data[[1]])
+  ))
 })
 
 test_that("Precision-Recall v2 represents one model in one population", {
@@ -113,21 +106,22 @@ test_that("Precision-Recall v2 shares one prevalence reference across models", {
     "Model B" = c(0.1, 0.4, 0.6, 0.9)
   )
   reals <- list("Population A" = c(0, 0, 1, 1))
+
   spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
     prepare_performance_data(probs, reals, by = 0.25),
     rtichoke:::build_evaluation_metadata(probs, reals)
   )
 
   expect_identical(
-    vapply(spec$evaluations, `[[`, character(1), "id"),
+    vapply(spec$evaluations, `[[`, "", "id"),
     c("evaluation-1", "evaluation-2")
   )
   expect_identical(
-    vapply(spec$series, `[[`, character(1), "id"),
+    vapply(spec$series, `[[`, "", "id"),
     c("series-1", "series-2")
   )
   expect_identical(
-    vapply(spec$evaluations, `[[`, character(1), "population"),
+    vapply(spec$evaluations, `[[`, "", "population"),
     c("Population A", "Population A")
   )
   expect_length(spec$references, 1)
@@ -135,91 +129,87 @@ test_that("Precision-Recall v2 shares one prevalence reference across models", {
   expect_identical(spec$references[[1]]$value, 0.5)
 })
 
-test_that(
-  "Precision-Recall v2 preserves population-shaped model-unknown semantics",
-  {
-    probs <- list(
-      "Population A" = c(0.05, 0.2, 0.7, 0.95),
-      "Population B" = c(0.1, 0.4, 0.6, 0.9)
-    )
-    reals <- list(
-      "Population A" = c(0, 0, 0, 1),
-      "Population B" = c(0, 0, 1, 1)
-    )
-    spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
-      prepare_performance_data(probs, reals, by = 0.25),
-      rtichoke:::build_evaluation_metadata(probs, reals)
-    )
+test_that("Precision-Recall v2 preserves population-shaped model-unknown semantics", {
+  probs <- list(
+    "Population A" = c(0.05, 0.2, 0.7, 0.95),
+    "Population B" = c(0.1, 0.4, 0.6, 0.9)
+  )
+  reals <- list(
+    "Population A" = c(0, 0, 0, 1),
+    "Population B" = c(0, 0, 1, 1)
+  )
 
-    expect_identical(
-      spec$evaluations,
+  spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  expect_identical(
+    spec$evaluations,
+    list(
+      list(id = "evaluation-1", population = "Population A"),
+      list(id = "evaluation-2", population = "Population B")
+    )
+  )
+  expect_false(any(vapply(
+    spec$evaluations,
+    function(x) "model" %in% names(x),
+    logical(1)
+  )))
+  expect_identical(
+    lapply(spec$series, `[[`, "display"),
+    list(
       list(
-        list(id = "evaluation-1", population = "Population A"),
-        list(id = "evaluation-2", population = "Population B")
+        label = "Population A",
+        group = "Population A",
+        role = "population"
+      ),
+      list(
+        label = "Population B",
+        group = "Population B",
+        role = "population"
       )
     )
-    expect_false(any(vapply(
-      spec$evaluations,
-      function(x) "model" %in% names(x),
-      logical(1)
-    )))
-    expect_identical(
-      lapply(spec$series, `[[`, "display"),
-      list(
-        list(
-          label = "Population A",
-          group = "Population A",
-          role = "population"
-        ),
-        list(
-          label = "Population B",
-          group = "Population B",
-          role = "population"
-        )
-      )
-    )
-    expect_identical(
-      vapply(spec$references, `[[`, character(1), "population"),
-      c("Population A", "Population B")
-    )
-    expect_identical(
-      vapply(spec$references, `[[`, numeric(1), "value"),
-      c(0.25, 0.5)
-    )
-  }
-)
+  )
+  expect_identical(
+    vapply(spec$references, `[[`, "", "population"),
+    c("Population A", "Population B")
+  )
+  expect_identical(
+    vapply(spec$references, `[[`, numeric(1), "value"),
+    c(0.25, 0.5)
+  )
+})
 
-test_that(
-  "Precision-Recall v2 keeps equal-prevalence populations as distinct owners",
-  {
-    probs <- list(
-      "Population A" = c(0.05, 0.2, 0.7, 0.95),
-      "Population B" = c(0.1, 0.4, 0.6, 0.9)
-    )
-    reals <- list(
-      "Population A" = c(0, 0, 1, 1),
-      "Population B" = c(0, 1, 0, 1)
-    )
-    spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
-      prepare_performance_data(probs, reals, by = 0.25),
-      rtichoke:::build_evaluation_metadata(probs, reals)
-    )
+test_that("Precision-Recall v2 keeps equal-prevalence populations as distinct owners", {
+  probs <- list(
+    "Population A" = c(0.05, 0.2, 0.7, 0.95),
+    "Population B" = c(0.1, 0.4, 0.6, 0.9)
+  )
+  reals <- list(
+    "Population A" = c(0, 0, 1, 1),
+    "Population B" = c(0, 1, 0, 1)
+  )
 
-    expect_length(spec$references, 2)
-    expect_identical(
-      vapply(spec$references, `[[`, character(1), "population"),
-      c("Population A", "Population B")
-    )
-    expect_identical(
-      vapply(spec$references, `[[`, numeric(1), "value"),
-      c(0.5, 0.5)
-    )
-    expect_false(identical(
-      spec$references[[1]]$population,
-      spec$references[[2]]$population
-    ))
-  }
-)
+  spec <- rtichoke:::rtichoke_viz_precision_recall_v2_spec(
+    prepare_performance_data(probs, reals, by = 0.25),
+    rtichoke:::build_evaluation_metadata(probs, reals)
+  )
+
+  expect_length(spec$references, 2)
+  expect_identical(
+    vapply(spec$references, `[[`, "", "population"),
+    c("Population A", "Population B")
+  )
+  expect_identical(
+    vapply(spec$references, `[[`, numeric(1), "value"),
+    c(0.5, 0.5)
+  )
+  expect_false(identical(
+    spec$references[[1]]$population,
+    spec$references[[2]]$population
+  ))
+})
 
 test_that("Precision-Recall v2 IDs are deterministic and label-independent", {
   probs <- list(
@@ -243,39 +233,41 @@ test_that("Precision-Recall v2 IDs are deterministic and label-independent", {
   )
 
   expect_identical(
-    vapply(spec$evaluations, `[[`, character(1), "id"),
+    vapply(spec$evaluations, `[[`, "", "id"),
     c("evaluation-1", "evaluation-2")
   )
   expect_identical(
-    vapply(spec$series, `[[`, character(1), "id"),
+    vapply(spec$series, `[[`, "", "id"),
     c("series-1", "series-2")
   )
   expect_identical(
-    vapply(spec$evaluations, `[[`, character(1), "id"),
-    vapply(renamed_spec$evaluations, `[[`, character(1), "id")
+    vapply(spec$evaluations, `[[`, "", "id"),
+    vapply(renamed_spec$evaluations, `[[`, "", "id")
   )
   expect_identical(
-    vapply(spec$series, `[[`, character(1), "id"),
-    vapply(renamed_spec$series, `[[`, character(1), "id")
+    vapply(spec$series, `[[`, "", "id"),
+    vapply(renamed_spec$series, `[[`, "", "id")
   )
 })
 
 test_that("Precision-Recall public renderers preserve historical defaults", {
   dat <- precision_recall_v2_fixture()
 
-  expect_s3_class(
-    create_precision_recall_curve(dat$probs, dat$reals, by = 0.25),
-    "plotly"
+  plotly_plot <- create_precision_recall_curve(
+    dat$probs,
+    dat$reals,
+    by = 0.25
   )
-  expect_s3_class(
-    create_precision_recall_curve(
-      dat$probs,
-      dat$reals,
-      by = 0.25,
-      interactive = FALSE
-    ),
-    "ggplot"
+  expect_s3_class(plotly_plot, "plotly")
+
+  ggplot_plot <- create_precision_recall_curve(
+    dat$probs,
+    dat$reals,
+    by = 0.25,
+    interactive = FALSE
   )
+  expect_s3_class(ggplot_plot, "ggplot")
+
   expect_s3_class(
     plot_precision_recall_curve(dat$performance_data, renderer = "plotly"),
     "plotly"
@@ -288,6 +280,7 @@ test_that("Precision-Recall public renderers preserve historical defaults", {
 
 test_that("Precision-Recall browser dispatch uses the canonical shared renderer", {
   dat <- precision_recall_v2_fixture()
+
   browser <- create_precision_recall_curve(
     dat$probs,
     dat$reals,
@@ -321,8 +314,8 @@ test_that("Precision-Recall browser dispatch uses the canonical shared renderer"
 
 test_that("public Precision-Recall browser artifact renders SVG from file", {
   skip_on_os("windows")
-  browser_bin <- precision_recall_headless_browser()
-  skip_if(!nzchar(browser_bin), "No headless Chromium/Chrome available")
+  browser <- precision_recall_headless_browser()
+  skip_if(!nzchar(browser), "No headless Chromium/Chrome available")
 
   dat <- precision_recall_v2_fixture()
   widget <- create_precision_recall_curve(
@@ -341,9 +334,10 @@ test_that("public Precision-Recall browser artifact renders SVG from file", {
     winslash = "/",
     mustWork = TRUE
   )
+  url <- paste0("file://", rendered_file)
   stderr_file <- tempfile("rtichoke-pr-browser-stderr-")
   dom_lines <- system2(
-    browser_bin,
+    browser,
     args = c(
       "--headless=new",
       "--no-sandbox",
@@ -351,7 +345,7 @@ test_that("public Precision-Recall browser artifact renders SVG from file", {
       "--disable-dev-shm-usage",
       "--virtual-time-budget=3000",
       "--dump-dom",
-      shQuote(paste0("file://", rendered_file))
+      shQuote(url)
     ),
     stdout = TRUE,
     stderr = stderr_file,
@@ -359,10 +353,7 @@ test_that("public Precision-Recall browser artifact renders SVG from file", {
   )
   status <- attr(dom_lines, "status")
   dom <- paste(dom_lines, collapse = "\n")
-  browser_stderr <- paste(
-    readLines(stderr_file, warn = FALSE),
-    collapse = "\n"
-  )
+  browser_stderr <- paste(readLines(stderr_file, warn = FALSE), collapse = "\n")
 
   expect_null(status, info = browser_stderr)
   expect_false(


### PR DESCRIPTION
## Summary

- add canonical static `PrecisionRecallV2Spec` production from existing performance rows
- reuse established evaluation/series identity and population prevalence machinery
- dispatch `precision_recall` to vendored `renderPrecisionRecallV2()`
- add opt-in `renderer = "browser"` support to `create_precision_recall_curve()` and the public precomputed-data `plot_precision_recall_curve()` API
- preserve Plotly/ggplot2 defaults and statistics unchanged
- add focused semantic, pass-through, compatibility, dispatch, and real-browser SVG tests

## Immutable renderer

This PR continues to consume the existing vendored `rtichoke_viz v0.5.0` artifact only:

- source commit `9c5a114ebe968e8cef4d2f14bf82ed552d2c8a17`
- archive `rtichoke-viz-0.5.0.tar.gz`
- SHA-256 `ab36ae71f9090b4de62da8f552ebe84ac35885ab04958667faaf070db2c98f65`

No renderer vendoring or shared-renderer changes are included.

## Scope

Static Precision-Recall only. No time-dependent PR, Decision Curves, ReportSpec, summary-report, Quarto, htmlwidgets, or statistical changes.