### PR TITLE
fix: filter non-finite lift values to prevent blank browser report page

### DIFF
--- a/R/rtichoke_viz_v2.R
+++ b/R/rtichoke_viz_v2.R
@@ -116,6 +116,9 @@ rtichoke_viz_lift_v2_spec <- function(
   performance_data,
   evaluation_metadata
 ) {
+  valid_rows <- is.finite(as.numeric(performance_data$ppcr)) &
+    is.finite(as.numeric(performance_data$lift))
+  performance_data <- performance_data[valid_rows, , drop = FALSE]
   spec <- rtichoke_viz_curve_v2_spec(
     performance_data,
     evaluation_metadata,


### PR DESCRIPTION
## Problem

When `ppcr = 0` (at the maximum probability threshold, where all observations are predicted negative), `lift = 0/0 = NaN` in R. `jsonlite::toJSON` serialises R's `NaN` as the JSON **string** `"NaN"` (with quotes), not as a number.

In the browser renderer, TypeBox validates `LiftV2DatumSchema` with `lift: Type.Number()`. A quoted string fails that check, so `Check(ReportSpecSchema, spec)` returns `false`, `renderReport` throws `"Invalid ReportSpec"`, and the container div is never populated — producing a blank white page when opening the report.

## Fix

Apply the same `is.finite()` guard already used in `rtichoke_viz_decision_curve_v2_spec`: drop rows where `ppcr` or `lift` is not finite before passing `performance_data` to `rtichoke_viz_curve_v2_spec`. This removes the undefined lift datum at `ppcr = 0` and keeps the spec valid for the browser renderer.

## Scope

- 1 file changed, 3 lines added
- No statistical behaviour change: a lift value of `NaN` at `ppcr = 0` is mathematically undefined and was already silently dropped by Plotly/ggplot2
- No public API change
- Existing tests pass (86/86 in `test-rtichoke-viz-v2.R`)