### PR TITLE
Browser summary report hierarchy parity cleanup

### DIFF
--- a/R/create_summary_report.R
+++ b/R/create_summary_report.R
@@ -251,27 +251,27 @@ summary_report_browser_spec <- function(probs, reals) {
           "By Probability Threshold",
           list(
             component("roc", "ROC", threshold_roc),
+            component("lift", "Lift", threshold_lift),
             component(
               "precision-recall",
               "Precision-Recall",
               threshold_precision_recall
             ),
-            component("gains", "Gains", threshold_gains),
-            component("lift", "Lift", threshold_lift)
+            component("gains", "Gains", threshold_gains)
           )
         ),
         group(
           "discrimination-ppcr",
-          "By PPCR",
+          "By Predicted Positives Condition Rate (PPCR)",
           list(
             component("roc-2", "ROC", ppcr_roc),
+            component("lift-2", "Lift", ppcr_lift),
             component(
               "precision-recall-2",
               "Precision-Recall",
               ppcr_precision_recall
             ),
-            component("gains-2", "Gains", ppcr_gains),
-            component("lift-2", "Lift", ppcr_lift)
+            component("gains-2", "Gains", ppcr_gains)
           )
         )
       )
@@ -303,7 +303,7 @@ summary_report_browser_spec <- function(probs, reals) {
         ),
         group(
           "performance-table-ppcr",
-          "By PPCR",
+          "By Predicted Positives Condition Rate (PPCR)",
           list(component(
             "performance-table-2",
             "Performance Table",

--- a/tests/testthat/test-summary-report-browser.R
+++ b/tests/testthat/test-summary-report-browser.R
@@ -48,13 +48,13 @@ summary_report_component_types <- c(
   "calibration",
   "summary_metrics",
   "roc",
+  "lift",
   "precision_recall",
   "gains",
-  "lift",
   "roc",
+  "lift",
   "precision_recall",
   "gains",
-  "lift",
   "decision_curve",
   "interventions_avoided",
   "performance_table",
@@ -68,13 +68,13 @@ summary_report_component_ids <- c(
   "calibration",
   "auroc",
   "roc",
+  "lift",
   "precision-recall",
   "gains",
-  "lift",
   "roc-2",
+  "lift-2",
   "precision-recall-2",
   "gains-2",
-  "lift-2",
   "decision-curve",
   "interventions-avoided",
   "performance-table",
@@ -219,14 +219,25 @@ test_that("browser summary report composes the structured v1.1 hierarchy", {
   )
   expect_identical(
     vapply(discrimination$items[2:3], `[[`, "", "title"),
-    c("By Probability Threshold", "By PPCR")
+    c(
+      "By Probability Threshold",
+      "By Predicted Positives Condition Rate (PPCR)"
+    )
   )
   for (group in discrimination$items[2:3]) {
     expect_identical(
       vapply(group$components, `[[`, "", "title"),
-      c("ROC", "Precision-Recall", "Gains", "Lift")
+      c("ROC", "Lift", "Precision-Recall", "Gains")
     )
   }
+  expect_identical(
+    vapply(discrimination$items[[2]]$components, `[[`, "", "id"),
+    c("roc", "lift", "precision-recall", "gains")
+  )
+  expect_identical(
+    vapply(discrimination$items[[3]]$components, `[[`, "", "id"),
+    c("roc-2", "lift-2", "precision-recall-2", "gains-2")
+  )
 
   utility <- report$sections[[4]]
   expect_identical(
@@ -244,7 +255,10 @@ test_that("browser summary report composes the structured v1.1 hierarchy", {
   )
   expect_identical(
     vapply(tables$items, `[[`, "", "title"),
-    c("By Probability Threshold", "By PPCR")
+    c(
+      "By Probability Threshold",
+      "By Predicted Positives Condition Rate (PPCR)"
+    )
   )
   expect_identical(
     vapply(tables$items, function(x) x$components[[1]]$title, ""),

--- a/tests/testthat/test-summary-report-browser.R
+++ b/tests/testthat/test-summary-report-browser.R
@@ -606,6 +606,7 @@ test_that("public browser report renders populated components from a local file"
       "--allow-file-access-from-files",
       "--disable-gpu",
       "--disable-dev-shm-usage",
+      "--virtual-time-budget=5000",
       "--run-all-tasks",
       "--dump-dom",
       shQuote(url)

--- a/tests/testthat/test-summary-report-browser.R
+++ b/tests/testthat/test-summary-report-browser.R
@@ -606,7 +606,6 @@ test_that("public browser report renders populated components from a local file"
       "--allow-file-access-from-files",
       "--disable-gpu",
       "--disable-dev-shm-usage",
-      "--virtual-time-budget=5000",
       "--run-all-tasks",
       "--dump-dom",
       shQuote(url)


### PR DESCRIPTION
Restore historical curve ordering (ROC -> Lift -> Precision-Recall -> Gains) and full PPCR group wording ('By Predicted Positives Condition Rate (PPCR)') in the browser summary report composition.

---
*PR created automatically by Jules for task [14063719929655080218](https://jules.google.com/task/14063719929655080218) started by @uriahf*