### PR TITLE
Add Performance Metrics Cheat Sheet to browser summary report

### DIFF
--- a/R/report_browser.R
+++ b/R/report_browser.R
@@ -37,13 +37,33 @@ render_rtichoke_viz_report_browser <- function(report_spec) {
     src = c(file = vendor_dir),
     stylesheet = "rtichoke-viz.css"
   )
+  cheat_sheet <- performance_metrics_cheat_sheet_html()
+  cheat_sheet_json <- jsonlite::toJSON(
+    cheat_sheet,
+    auto_unbox = TRUE,
+    null = "null"
+  )
+  cheat_sheet_json <- gsub("</", "<\\/", cheat_sheet_json, fixed = TRUE)
+
   initializer <- paste0(
     "const spec = JSON.parse(document.querySelector('#",
     id,
     "-spec').textContent);\n",
+    "const reportNode = renderReport(spec, { sectionGroupPresentation: 'tabs', groupPresentation: 'stacked' });\n",
+    "const headerNode = reportNode.querySelector('.rtichoke-report__header');\n",
+    "const cheatSheetWrapper = document.createElement('div');\n",
+    "cheatSheetWrapper.innerHTML = ",
+    cheat_sheet_json,
+    ";\n",
+    "const cheatSheetNode = cheatSheetWrapper.firstElementChild;\n",
+    "if (headerNode && headerNode.nextSibling) {\n",
+    "  reportNode.insertBefore(cheatSheetNode, headerNode.nextSibling);\n",
+    "} else {\n",
+    "  reportNode.appendChild(cheatSheetNode);\n",
+    "}\n",
     "document.querySelector('#",
     id,
-    "').append(renderReport(spec, { sectionGroupPresentation: 'tabs', groupPresentation: 'stacked' }));"
+    "').append(reportNode);"
   )
   script <- paste(bundle, initializer, sep = "\n")
 
@@ -59,4 +79,83 @@ render_rtichoke_viz_report_browser <- function(report_spec) {
     ),
     dependency
   ))
+}
+
+#' Generate Performance Metrics Cheat Sheet HTML for browser summary reports
+#'
+#' @return A character string containing R-owned browser-native HTML for the
+#'   Performance Metrics Cheat Sheet.
+#' @noRd
+performance_metrics_cheat_sheet_html <- function() {
+  paste0(
+    "<details class=\"rtichoke-cheat-sheet\">\n",
+    "  <summary>Performance Metrics Cheat Sheet</summary>\n",
+    "  <div class=\"rtichoke-cheat-sheet__content\">\n",
+    "    <section class=\"rtichoke-cheat-sheet__section\">\n",
+    "      <h4>Confusion Matrix</h4>\n",
+    "      <table class=\"rtichoke-cheat-sheet__table\">\n",
+    "        <thead>\n",
+    "          <tr>\n",
+    "            <th></th>\n",
+    "            <th>Predicted +</th>\n",
+    "            <th>Predicted -</th>\n",
+    "          </tr>\n",
+    "        </thead>\n",
+    "        <tbody>\n",
+    "          <tr>\n",
+    "            <th>Real Positive</th>\n",
+    "            <td>TP</td>\n",
+    "            <td>FN</td>\n",
+    "          </tr>\n",
+    "          <tr>\n",
+    "            <th>Real Negative</th>\n",
+    "            <td>FP</td>\n",
+    "            <td>TN</td>\n",
+    "          </tr>\n",
+    "        </tbody>\n",
+    "      </table>\n",
+    "    </section>\n",
+    "    <section class=\"rtichoke-cheat-sheet__section\">\n",
+    "      <h4>Metrics &amp; Formulas</h4>\n",
+    "      <dl class=\"rtichoke-cheat-sheet__metrics\">\n",
+    "        <dt>Prevalence</dt>\n",
+    "        <dd><code>(TP + FN) / (TP + FP + TN + FN)</code></dd>\n",
+    "        <dt>PPCR</dt>\n",
+    "        <dd><code>(TP + FP) / (TP + FP + TN + FN)</code></dd>\n",
+    "        <dt>Sensitivity / Recall / TPR</dt>\n",
+    "        <dd>\n",
+    "          <code>TP / (TP + FN)</code><br />\n",
+    "          <code>TP / Real Positives</code><br />\n",
+    "          <code>P(Predicted Positive | Real Positive)</code>\n",
+    "        </dd>\n",
+    "        <dt>Specificity / TNR</dt>\n",
+    "        <dd>\n",
+    "          <code>TN / (TN + FP)</code><br />\n",
+    "          <code>TN / Real Negatives</code><br />\n",
+    "          <code>P(Predicted Negative | Real Negative)</code>\n",
+    "        </dd>\n",
+    "        <dt>PPV / Precision</dt>\n",
+    "        <dd>\n",
+    "          <code>TP / (TP + FP)</code><br />\n",
+    "          <code>TP / Predicted Positives</code><br />\n",
+    "          <code>P(Real Positive | Predicted Positive)</code>\n",
+    "        </dd>\n",
+    "        <dt>NPV</dt>\n",
+    "        <dd>\n",
+    "          <code>TN / (TN + FN)</code><br />\n",
+    "          <code>TN / Predicted Negatives</code><br />\n",
+    "          <code>P(Real Negative | Predicted Negative)</code>\n",
+    "        </dd>\n",
+    "        <dt>Lift</dt>\n",
+    "        <dd><code>PPV / Prevalence</code></dd>\n",
+    "        <dt>Net Benefit</dt>\n",
+    "        <dd>\n",
+    "          <code>TP / N - FP / N * p_t / (1 - p_t)</code><br />\n",
+    "          <small>where N = TP + FP + TN + FN</small>\n",
+    "        </dd>\n",
+    "      </dl>\n",
+    "    </section>\n",
+    "  </div>\n",
+    "</details>"
+  )
 }

--- a/tests/testthat/test-summary-report-browser.R
+++ b/tests/testthat/test-summary-report-browser.R
@@ -700,11 +700,22 @@ test_that("browser summary report includes the Performance Metrics Cheat Sheet",
 
   html <- paste(readLines(rendered_file, warn = FALSE), collapse = "\n")
 
-  cheat_sheet_occurrences <- length(gregexpr("Performance Metrics Cheat Sheet", html)[[1]])
+  cheat_sheet_occurrences <- length(gregexpr(
+    "Performance Metrics Cheat Sheet",
+    html
+  )[[1]])
   expect_equal(cheat_sheet_occurrences, 1)
 
-  expect_match(html, "<details class=\\\"rtichoke-cheat-sheet\\\">", fixed = TRUE)
-  expect_match(html, "<summary>Performance Metrics Cheat Sheet<\\/summary>", fixed = TRUE)
+  expect_match(
+    html,
+    "<details class=\\\"rtichoke-cheat-sheet\\\">",
+    fixed = TRUE
+  )
+  expect_match(
+    html,
+    "<summary>Performance Metrics Cheat Sheet<\\/summary>",
+    fixed = TRUE
+  )
 
   # Confusion matrix labels
   expect_match(html, "Real Positive", fixed = TRUE)
@@ -754,7 +765,11 @@ test_that("browser summary report includes the Performance Metrics Cheat Sheet",
 
   browser <- find_headless_browser()
   if (nzchar(browser)) {
-    rendered_file_norm <- normalizePath(rendered_file, winslash = "/", mustWork = TRUE)
+    rendered_file_norm <- normalizePath(
+      rendered_file,
+      winslash = "/",
+      mustWork = TRUE
+    )
     url <- paste0("file://", rendered_file_norm)
     stderr_file <- tempfile("rtichoke-browser-stderr-")
     dom_lines <- system2(
@@ -783,7 +798,10 @@ test_that("browser summary report includes the Performance Metrics Cheat Sheet",
     expect_true(cs_pos > 0, info = "Cheat sheet node found")
     expect_true(nav_pos > 0, info = "Nav node found")
 
-    expect_true(header_pos < cs_pos, info = "Cheat sheet is placed AFTER header")
+    expect_true(
+      header_pos < cs_pos,
+      info = "Cheat sheet is placed AFTER header"
+    )
     expect_true(cs_pos < nav_pos, info = "Cheat sheet is placed BEFORE nav")
   }
 })

--- a/tests/testthat/test-summary-report-browser.R
+++ b/tests/testthat/test-summary-report-browser.R
@@ -681,3 +681,109 @@ test_that("public browser report renders populated components from a local file"
     info = browser_stderr
   )
 })
+
+
+test_that("browser summary report includes the Performance Metrics Cheat Sheet", {
+  dat <- summary_report_test_data()
+  output_dir <- tempfile("rtichoke-summary-cheatsheet-")
+
+  create_summary_report(
+    probs = dat$probs,
+    reals = dat$reals,
+    renderer = "browser",
+    output_file = "browser_report.html",
+    output_dir = output_dir
+  )
+
+  rendered_file <- file.path(output_dir, "browser_report.html")
+  expect_true(file.exists(rendered_file))
+
+  html <- paste(readLines(rendered_file, warn = FALSE), collapse = "\n")
+
+  cheat_sheet_occurrences <- length(gregexpr("Performance Metrics Cheat Sheet", html)[[1]])
+  expect_equal(cheat_sheet_occurrences, 1)
+
+  expect_match(html, "<details class=\\\"rtichoke-cheat-sheet\\\">", fixed = TRUE)
+  expect_match(html, "<summary>Performance Metrics Cheat Sheet<\\/summary>", fixed = TRUE)
+
+  # Confusion matrix labels
+  expect_match(html, "Real Positive", fixed = TRUE)
+  expect_match(html, "Real Negative", fixed = TRUE)
+  expect_match(html, "Predicted +", fixed = TRUE)
+  expect_match(html, "Predicted -", fixed = TRUE)
+  expect_match(html, "<td>TP<\\/td>", fixed = TRUE)
+  expect_match(html, "<td>FP<\\/td>", fixed = TRUE)
+  expect_match(html, "<td>TN<\\/td>", fixed = TRUE)
+  expect_match(html, "<td>FN<\\/td>", fixed = TRUE)
+
+  # Metric names
+  expect_match(html, "<dt>Prevalence<\\/dt>", fixed = TRUE)
+  expect_match(html, "<dt>PPCR<\\/dt>", fixed = TRUE)
+  expect_match(html, "Sensitivity", fixed = TRUE)
+  expect_match(html, "Specificity", fixed = TRUE)
+  expect_match(html, "Precision", fixed = TRUE)
+  expect_match(html, "<dt>NPV<\\/dt>", fixed = TRUE)
+  expect_match(html, "<dt>Lift<\\/dt>", fixed = TRUE)
+  expect_match(html, "<dt>Net Benefit<\\/dt>", fixed = TRUE)
+
+  # Metric formulas
+  expect_match(html, "(TP + FN) / (TP + FP + TN + FN)", fixed = TRUE)
+  expect_match(html, "(TP + FP) / (TP + FP + TN + FN)", fixed = TRUE)
+  expect_match(html, "TP / (TP + FN)", fixed = TRUE)
+  expect_match(html, "TP / Real Positives", fixed = TRUE)
+  expect_match(html, "P(Predicted Positive | Real Positive)", fixed = TRUE)
+  expect_match(html, "TN / (TN + FP)", fixed = TRUE)
+  expect_match(html, "TN / Real Negatives", fixed = TRUE)
+  expect_match(html, "P(Predicted Negative | Real Negative)", fixed = TRUE)
+  expect_match(html, "TP / (TP + FP)", fixed = TRUE)
+  expect_match(html, "TP / Predicted Positives", fixed = TRUE)
+  expect_match(html, "P(Real Positive | Predicted Positive)", fixed = TRUE)
+  expect_match(html, "TN / (TN + FN)", fixed = TRUE)
+  expect_match(html, "TN / Predicted Negatives", fixed = TRUE)
+  expect_match(html, "P(Real Negative | Predicted Negative)", fixed = TRUE)
+  expect_match(html, "PPV / Prevalence", fixed = TRUE)
+  expect_match(html, "TP / N - FP / N * p_t / (1 - p_t)", fixed = TRUE)
+  expect_match(html, "N = TP + FP + TN + FN", fixed = TRUE)
+
+  # DOM placement relative ordering
+  expect_match(
+    html,
+    "insertBefore(cheatSheetNode, headerNode.nextSibling)",
+    fixed = TRUE
+  )
+
+  browser <- find_headless_browser()
+  if (nzchar(browser)) {
+    rendered_file_norm <- normalizePath(rendered_file, winslash = "/", mustWork = TRUE)
+    url <- paste0("file://", rendered_file_norm)
+    stderr_file <- tempfile("rtichoke-browser-stderr-")
+    dom_lines <- system2(
+      browser,
+      args = c(
+        "--headless=new",
+        "--no-sandbox",
+        "--allow-file-access-from-files",
+        "--disable-gpu",
+        "--disable-dev-shm-usage",
+        "--run-all-tasks",
+        "--dump-dom",
+        shQuote(url)
+      ),
+      stdout = TRUE,
+      stderr = stderr_file,
+      timeout = 20
+    )
+    dom <- paste(dom_lines, collapse = "\n")
+
+    header_pos <- regexpr("class=\"rtichoke-report__header\"", dom)[1]
+    cs_pos <- regexpr("class=\"rtichoke-cheat-sheet\"", dom)[1]
+    nav_pos <- regexpr("class=\"rtichoke-report__nav\"", dom)[1]
+
+    expect_true(header_pos > 0, info = "Header node found")
+    expect_true(cs_pos > 0, info = "Cheat sheet node found")
+    expect_true(nav_pos > 0, info = "Nav node found")
+
+    expect_true(header_pos < cs_pos, info = "Cheat sheet is placed AFTER header")
+    expect_true(cs_pos < nav_pos, info = "Cheat sheet is placed BEFORE nav")
+  }
+})


### PR DESCRIPTION
Adds R-owned browser-native HTML for the Performance Metrics Cheat Sheet to `create_summary_report(..., renderer = "browser")`. The Cheat Sheet is rendered as a collapsible `<details>`/`<summary>` element inserted client-side after `.rtichoke-report__header` and before `.rtichoke-report__nav`. Includes confusion matrix and performance metric formulas without altering ReportSpec, vendor JS/CSS, or default RMarkdown rendering.

---
*PR created automatically by Jules for task [12452597777815534591](https://jules.google.com/task/12452597777815534591) started by @uriahf*