### PR TITLE
Add private outcome-weighted calibration bin primitive

### DIFF
--- a/R/calibration_weights.R
+++ b/R/calibration_weights.R
@@ -1,0 +1,116 @@
+#' Prepare calibration bins with optional outcome weights
+#'
+#' Private vector-level primitive for calibration preparation. Prediction bins
+#' and their displayed predicted values are always defined from the target
+#' population predictions. Optional `outcome_weights` affect only the observed
+#' outcome estimate within each bin.
+#'
+#' When `outcome_weights` is `NULL`, this delegates to the established
+#' `make_deciles_dat()` implementation so factual calibration semantics remain
+#' exactly unchanged.
+#'
+#' @param probs Numeric vector of predicted probabilities.
+#' @param reals Numeric vector of binary outcomes.
+#' @param outcome_weights Optional non-negative finite weights used only for the
+#'   observed outcome mean.
+#' @param n_bins Number of equal-frequency prediction bins. The historical
+#'   unweighted path currently supports 10 bins only.
+#'
+#' @return A tibble with the established calibration-bin columns plus
+#'   `outcome_weight_sum`. For weighted calls, `y` is the weighted observed
+#'   outcome mean while `x` remains the unweighted mean prediction.
+#' @noRd
+prepare_calibration_bins <- function(
+  probs,
+  reals,
+  outcome_weights = NULL,
+  n_bins = 10
+) {
+  if (length(probs) != length(reals)) {
+    stop("`probs` and `reals` must have the same length.", call. = FALSE)
+  }
+
+  if (is.null(outcome_weights)) {
+    if (!identical(n_bins, 10L) && !identical(n_bins, 10)) {
+      stop(
+        "The established unweighted calibration path currently supports `n_bins = 10` only.",
+        call. = FALSE
+      )
+    }
+
+    return(
+      make_deciles_dat(probs, reals) |>
+        dplyr::mutate(outcome_weight_sum = total_obs)
+    )
+  }
+
+  if (length(outcome_weights) != length(reals)) {
+    stop(
+      "`outcome_weights` must have the same length as `reals`.",
+      call. = FALSE
+    )
+  }
+  if (
+    length(n_bins) != 1 ||
+      is.na(n_bins) ||
+      !is.numeric(n_bins) ||
+      n_bins < 1 ||
+      n_bins != as.integer(n_bins)
+  ) {
+    stop("`n_bins` must be a positive integer.", call. = FALSE)
+  }
+  if (
+    any(!is.finite(outcome_weights)) ||
+      any(outcome_weights < 0)
+  ) {
+    stop(
+      "`outcome_weights` must contain only finite, non-negative values.",
+      call. = FALSE
+    )
+  }
+
+  dat <- data.frame(
+    probs = probs,
+    reals = reals,
+    outcome_weights = outcome_weights
+  )
+
+  if (length(unique(probs)) == 1) {
+    dat$quintile <- 1L
+  } else {
+    dat <- dat |>
+      dplyr::mutate(quintile = dplyr::ntile(probs, as.integer(n_bins)))
+  }
+
+  bins <- dat |>
+    dplyr::group_by(quintile) |>
+    dplyr::summarise(
+      x = mean(probs),
+      outcome_weight_sum = sum(outcome_weights),
+      weighted_sum_reals = sum(outcome_weights * reals),
+      sum_reals = sum(reals),
+      total_obs = dplyr::n(),
+      .groups = "drop"
+    )
+
+  if (any(bins$outcome_weight_sum <= 0)) {
+    stop(
+      "Every calibration bin must have positive total `outcome_weights`.",
+      call. = FALSE
+    )
+  }
+
+  bins |>
+    dplyr::mutate(
+      y = weighted_sum_reals / outcome_weight_sum
+    ) |>
+    dplyr::select(
+      quintile,
+      x,
+      y,
+      sum_reals,
+      total_obs,
+      outcome_weight_sum,
+      weighted_sum_reals
+    )
+}

--- a/tests/testthat/test-calibration-weights.R
+++ b/tests/testthat/test-calibration-weights.R
@@ -32,9 +32,9 @@ test_that("outcome weights change observed calibration but not bins or predicted
 
   expect_equal(weighted$quintile, unweighted_two_bins$quintile)
   expect_equal(weighted$x, unweighted_two_bins$x)
-  expect_equal(weighted$y, c(3 / 6, 6 / 8))
+  expect_equal(weighted$y, c(4 / 6, 6 / 8))
   expect_equal(weighted$outcome_weight_sum, c(6, 8))
-  expect_equal(weighted$weighted_sum_reals, c(3, 6))
+  expect_equal(weighted$weighted_sum_reals, c(4, 6))
 })
 
 

--- a/tests/testthat/test-calibration-weights.R
+++ b/tests/testthat/test-calibration-weights.R
@@ -1,0 +1,98 @@
+test_that("unweighted private calibration bins preserve established factual semantics", {
+  probs <- seq(0.05, 0.95, length.out = 20)
+  reals <- rep(c(0, 1), 10)
+
+  expected <- rtichoke:::make_deciles_dat(probs, reals)
+  actual <- rtichoke:::prepare_calibration_bins(probs, reals)
+
+  expect_equal(actual$quintile, expected$quintile)
+  expect_equal(actual$x, expected$x)
+  expect_equal(actual$y, expected$y)
+  expect_equal(actual$sum_reals, expected$sum_reals)
+  expect_equal(actual$total_obs, expected$total_obs)
+  expect_equal(actual$outcome_weight_sum, expected$total_obs)
+})
+
+
+test_that("outcome weights change observed calibration but not bins or predicted means", {
+  probs <- c(0.10, 0.20, 0.30, 0.40, 0.60, 0.70, 0.80, 0.90)
+  reals <- c(0, 1, 0, 1, 1, 0, 1, 0)
+  weights <- c(1, 3, 1, 1, 2, 1, 4, 1)
+
+  weighted <- rtichoke:::prepare_calibration_bins(
+    probs,
+    reals,
+    outcome_weights = weights,
+    n_bins = 2
+  )
+  unweighted_two_bins <- data.frame(probs, reals) |>
+    dplyr::mutate(quintile = dplyr::ntile(probs, 2)) |>
+    dplyr::group_by(quintile) |>
+    dplyr::summarise(x = mean(probs), .groups = "drop")
+
+  expect_equal(weighted$quintile, unweighted_two_bins$quintile)
+  expect_equal(weighted$x, unweighted_two_bins$x)
+  expect_equal(weighted$y, c(3 / 6, 6 / 8))
+  expect_equal(weighted$outcome_weight_sum, c(6, 8))
+  expect_equal(weighted$weighted_sum_reals, c(3, 6))
+})
+
+
+test_that("all-one outcome weights reproduce unweighted bin estimates", {
+  probs <- seq(0.05, 0.95, length.out = 20)
+  reals <- rep(c(0, 1), 10)
+
+  unweighted <- rtichoke:::prepare_calibration_bins(probs, reals)
+  weighted <- rtichoke:::prepare_calibration_bins(
+    probs,
+    reals,
+    outcome_weights = rep(1, length(reals))
+  )
+
+  expect_equal(weighted$x, unweighted$x)
+  expect_equal(weighted$y, unweighted$y)
+  expect_equal(weighted$sum_reals, unweighted$sum_reals)
+  expect_equal(weighted$total_obs, unweighted$total_obs)
+})
+
+
+test_that("private weighted calibration bins validate weights", {
+  probs <- c(0.1, 0.2, 0.8, 0.9)
+  reals <- c(0, 1, 1, 0)
+
+  expect_error(
+    rtichoke:::prepare_calibration_bins(
+      probs,
+      reals,
+      outcome_weights = c(1, 1)
+    ),
+    "same length"
+  )
+  expect_error(
+    rtichoke:::prepare_calibration_bins(
+      probs,
+      reals,
+      outcome_weights = c(1, -1, 1, 1),
+      n_bins = 2
+    ),
+    "finite, non-negative"
+  )
+  expect_error(
+    rtichoke:::prepare_calibration_bins(
+      probs,
+      reals,
+      outcome_weights = c(1, Inf, 1, 1),
+      n_bins = 2
+    ),
+    "finite, non-negative"
+  )
+  expect_error(
+    rtichoke:::prepare_calibration_bins(
+      probs,
+      reals,
+      outcome_weights = c(1, 1, 0, 0),
+      n_bins = 2
+    ),
+    "positive total"
+  )
+})


### PR DESCRIPTION
## Summary

Adds a private vector-level calibration preparation helper for future `rticausal` reuse.

- keeps `create_calibration_curve()` and all public APIs unchanged
- delegates unweighted calls to the established `make_deciles_dat()` path
- optional `outcome_weights` affect only the observed outcome estimate within prediction bins
- bin membership and mean predicted risk remain defined by the target-population predictions
- preserves raw event/observation counts separately from weighted outcome totals
- rejects invalid weights and bins with zero total outcome weight
- adds regression tests showing factual parity and hand-calculable weighted behavior

This is deliberately not wired into current rtichoke rendering yet; it is a private statistical preparation primitive intended to support causal/interventional calibration without duplicating the established factual calibration machinery.