### PR TITLE
Make browser summary reports self-contained

### DIFF
--- a/.github/workflows/quarto-browser-summary-acceptance.yaml
+++ b/.github/workflows/quarto-browser-summary-acceptance.yaml
@@ -75,7 +75,7 @@ jobs:
           test -f tests/integration/quarto-browser-summary.html
           test -f tests/integration/summary-report-one.html
           test -f tests/integration/summary-report-two.html
-          test -f tests/integration/lib/rtichoke-viz-0.20.1/rtichoke-viz.css
+          ! test -d tests/integration/lib
 
       - name: Execute Quarto hosts in real Chrome
         run: |

--- a/R/report_browser.R
+++ b/R/report_browser.R
@@ -31,12 +31,15 @@ render_rtichoke_viz_report_browser <- function(report_spec) {
   )
   bundle <- gsub("</", "<\\/", bundle, fixed = TRUE)
 
-  dependency <- htmltools::htmlDependency(
-    name = "rtichoke-viz",
-    version = "0.20.1",
-    src = c(file = vendor_dir),
-    stylesheet = "rtichoke-viz.css"
+  viz_css <- paste(
+    readLines(
+      file.path(vendor_dir, "rtichoke-viz.css"),
+      warn = FALSE,
+      encoding = "UTF-8"
+    ),
+    collapse = "\n"
   )
+
   cheat_sheet <- performance_metrics_cheat_sheet_html()
   cheat_sheet_json <- jsonlite::toJSON(
     cheat_sheet,
@@ -67,8 +70,9 @@ render_rtichoke_viz_report_browser <- function(report_spec) {
   )
   script <- paste(bundle, initializer, sep = "\n")
 
-  htmltools::browsable(htmltools::attachDependencies(
+  htmltools::browsable(
     htmltools::tagList(
+      htmltools::tags$style(htmltools::HTML(viz_css)),
       htmltools::tags$style(htmltools::HTML(summary_report_density_css())),
       htmltools::tags$div(id = id, class = "rtichoke-viz-report"),
       htmltools::tags$script(
@@ -77,9 +81,8 @@ render_rtichoke_viz_report_browser <- function(report_spec) {
         htmltools::HTML(json)
       ),
       htmltools::tags$script(type = "module", htmltools::HTML(script))
-    ),
-    dependency
-  ))
+    )
+  )
 }
 
 #' Generate layout density CSS for browser summary reports

--- a/tests/integration/quarto-browser-summary-single.qmd
+++ b/tests/integration/quarto-browser-summary-single.qmd
@@ -24,9 +24,14 @@ format:
       const decisionCurve = component("decision-curve")?.querySelector("svg");
       const interventionsAvoided = component("interventions-avoided")?.querySelector("svg");
       const report = doc.querySelector(".rtichoke-report");
-      const cssLoaded = Array.from(doc.styleSheets).some(sheet =>
-        (sheet.href || "").includes("rtichoke-viz-0.20.1/rtichoke-viz.css")
-      );
+      const cssLoaded = Array.from(doc.styleSheets).some(sheet => {
+        if ((sheet.href || "").includes("rtichoke-viz")) return true;
+        try {
+          return Array.from(sheet.cssRules || []).some(rule => (rule.cssText || "").includes("rtichoke"));
+        } catch (e) {
+          return false;
+        }
+      });
       const styled = report && getComputedStyle(report).display !== "none";
       function testTableDisclosure(tableNode, expectedOpType) {
         if (!tableNode) return false;

--- a/tests/integration/quarto-browser-summary.qmd
+++ b/tests/integration/quarto-browser-summary.qmd
@@ -28,9 +28,14 @@ format:
     const decisionCurve = component("decision-curve")?.querySelector("svg");
     const interventionsAvoided = component("interventions-avoided")?.querySelector("svg");
     const report = doc.querySelector(".rtichoke-report");
-    const cssLoaded = Array.from(doc.styleSheets).some(sheet =>
-      (sheet.href || "").includes("rtichoke-viz-0.20.1/rtichoke-viz.css")
-    );
+    const cssLoaded = Array.from(doc.styleSheets).some(sheet => {
+      if ((sheet.href || "").includes("rtichoke-viz")) return true;
+      try {
+        return Array.from(sheet.cssRules || []).some(rule => (rule.cssText || "").includes("rtichoke"));
+      } catch (e) {
+        return false;
+      }
+    });
     const styled = report && getComputedStyle(report).display !== "none";
     return {
       table: !!table,

--- a/tests/testthat/test-report-browser.R
+++ b/tests/testthat/test-report-browser.R
@@ -66,7 +66,7 @@ test_that("browser ReportSpec path delegates complete report to renderReport", {
 
   expect_s3_class(browser, "shiny.tag.list")
   expect_match(html, "renderReport", fixed = TRUE)
-  expect_equal(htmltools::htmlDependencies(browser)[[1]]$version, "0.20.1")
+  expect_null(htmltools::htmlDependencies(browser))
   expect_match(html, expected_json, fixed = TRUE)
   expect_match(html, "max-width: 1040px;", fixed = TRUE)
   expect_match(html, "min-height: 500px;", fixed = TRUE)

--- a/tests/testthat/test-summary-report-browser.R
+++ b/tests/testthat/test-summary-report-browser.R
@@ -559,7 +559,8 @@ test_that("public browser renderer writes file-safe shared renderReport HTML", {
 
   html <- paste(readLines(rendered_file, warn = FALSE), collapse = "\n")
   expect_match(html, "renderReport", fixed = TRUE)
-  expect_match(html, "rtichoke-viz-0.20.1", fixed = TRUE)
+  expect_match(html, ".rtichoke-report", fixed = TRUE)
+  expect_match(html, ".rtichoke-viz-chart", fixed = TRUE)
   expect_match(html, '"id":"prevalence-summary"', fixed = TRUE)
   expect_match(html, '"id":"calibration-smooth"', fixed = TRUE)
   expect_match(html, '"id":"calibration"', fixed = TRUE)
@@ -572,10 +573,19 @@ test_that("public browser renderer writes file-safe shared renderReport HTML", {
   expect_match(html, '"id":"performance-table-2"', fixed = TRUE)
   expect_false(grepl("import { renderReport } from", html, fixed = TRUE))
   expect_false(grepl(
-    'src="lib/rtichoke-viz-0.20.1/rtichoke-viz.js"',
+    'rtichoke-viz.js',
     html,
     fixed = TRUE
   ))
+  expect_false(grepl(
+    'rtichoke-viz.css',
+    html,
+    fixed = TRUE
+  ))
+
+  # Verify no dependency directory was created
+  output_files <- list.files(output_dir, recursive = TRUE)
+  expect_identical(output_files, "browser_report.html")
 })
 
 


### PR DESCRIPTION
This change makes browser summary reports produced by create_summary_report(..., renderer = "browser") truly self-contained as a single standalone HTML file. It inlines the vendored rtichoke-viz.css stylesheet alongside the existing inline JS runtime and removes the external htmltools htmlDependency(), eliminating extra asset directory copying (lib/) while preserving all statistical calculations, canonical specs, CSS cascade rules, and report behaviors.

---
*PR created automatically by Jules for task [15840253223525760609](https://jules.google.com/task/15840253223525760609) started by @uriahf*