### PR TITLE
Generalize calibration bins

### DIFF
--- a/R/calibration.R
+++ b/R/calibration.R
@@ -107,11 +107,23 @@ create_calibration_curve <- function(
     "#585123"
   ),
   type = "discrete",
-  n_bins = 10,
-  size = NULL
+  size = NULL,
+  n_bins = 10
 ) {
   check_probs_input(probs)
   check_real_input(reals)
+
+  # Validate n_bins even for smooth calls
+  if (
+    !is.numeric(n_bins) ||
+      length(n_bins) != 1L ||
+      is.na(n_bins) ||
+      !is.finite(n_bins) ||
+      n_bins <= 0 ||
+      (n_bins %% 1 != 0)
+  ) {
+    stop("`n_bins` must be a single positive whole number.", call. = FALSE)
+  }
 
   effective_n_bins <- if (type == "discrete") n_bins else 10
 
@@ -119,8 +131,8 @@ create_calibration_curve <- function(
     probs = probs,
     reals = reals,
     color_values = color_values,
-    n_bins = effective_n_bins,
-    size = size
+    size = size,
+    n_bins = effective_n_bins
   )
 
   if (interactive == TRUE) {
@@ -237,8 +249,8 @@ create_calibration_curve_list <- function(
     "#D1603D",
     "#585123"
   ),
-  n_bins = 10,
-  size = NULL
+  size = NULL,
+  n_bins = 10
 ) {
   check_probs_input(probs)
   check_real_input(reals)
@@ -607,7 +619,7 @@ make_calibration_bins_dat <- function(
 
   if (length(unique(probs)) == 1) {
     tibble::tibble(
-      bin = 1,
+      bin = 1L,
       x = unique(probs),
       y = mean(reals),
       sum_reals = sum(reals),

--- a/R/calibration.R
+++ b/R/calibration.R
@@ -2,6 +2,7 @@
 #'
 #' @inheritParams create_roc_curve
 #' @param type discrete or smooth
+#' @param n_bins Number of calibration bins for binned calibration (default 10).
 #'
 #' @export
 #'
@@ -106,15 +107,19 @@ create_calibration_curve <- function(
     "#585123"
   ),
   type = "discrete",
+  n_bins = 10,
   size = NULL
 ) {
   check_probs_input(probs)
   check_real_input(reals)
 
+  effective_n_bins <- if (type == "discrete") n_bins else 10
+
   calibration_curve_list <- create_calibration_curve_list(
     probs = probs,
     reals = reals,
     color_values = color_values,
+    n_bins = effective_n_bins,
     size = size
   )
 
@@ -132,24 +137,24 @@ create_calibration_curve <- function(
 
 #' Define limits for Calibration Curve
 #'
-#' @param deciles_dat A data frame containing decile-level calibration data.
+#' @param calibration_bins_dat A data frame containing bin-level calibration data.
 #'
 #' @keywords internal
 #' @examples
 #' \dontrun{
-#' make_deciles_dat(
+#' make_calibration_bins_dat(
 #'   probs = example_dat$estimated_probabilities,
-#'   real = example_dat$outcome
+#'   reals = example_dat$outcome
 #' ) |>
 #'   define_limits_for_calibration_plot()
 #' }
-define_limits_for_calibration_plot <- function(deciles_dat) {
-  if (nrow(deciles_dat) == 1) {
+define_limits_for_calibration_plot <- function(calibration_bins_dat) {
+  if (nrow(calibration_bins_dat) == 1) {
     l <- 0
     u <- 1
   } else {
-    l <- max(0, min(deciles_dat$x, deciles_dat$y))
-    u <- max(deciles_dat$x, deciles_dat$y)
+    l <- max(0, min(calibration_bins_dat$x, calibration_bins_dat$y))
+    u <- max(calibration_bins_dat$x, calibration_bins_dat$y)
   }
 
   limits <- c(
@@ -164,6 +169,7 @@ define_limits_for_calibration_plot <- function(deciles_dat) {
 #' Create a Calibration Curve List
 #'
 #' @inheritParams create_roc_curve
+#' @param n_bins Number of calibration bins for binned calibration (default 10).
 #'
 #' @export
 #'
@@ -231,6 +237,7 @@ create_calibration_curve_list <- function(
     "#D1603D",
     "#585123"
   ),
+  n_bins = 10,
   size = NULL
 ) {
   check_probs_input(probs)
@@ -258,13 +265,13 @@ create_calibration_curve_list <- function(
   ) |>
     as.list()
 
-  # Create Deciles Dat
+  # Create Calibration Bins Dat
 
   if (calibration_curve_list$performance_type == "several populations") {
-    calibration_curve_list$deciles_dat <- purrr::map2_dfr(
+    calibration_curve_list$calibration_bins_dat <- purrr::map2_dfr(
       probs,
       reals,
-      ~ make_deciles_dat(.x, .y),
+      ~ make_calibration_bins_dat(.x, .y, n_bins = n_bins),
       .id = "reference_group"
     )
 
@@ -286,9 +293,9 @@ create_calibration_curve_list <- function(
     ) |>
       stats::na.omit()
   } else {
-    calibration_curve_list$deciles_dat <- purrr::map_df(
+    calibration_curve_list$calibration_bins_dat <- purrr::map_df(
       probs,
-      ~ make_deciles_dat(.x, reals[[1]]),
+      ~ make_calibration_bins_dat(.x, reals[[1]], n_bins = n_bins),
       .id = "reference_group"
     )
 
@@ -319,7 +326,7 @@ create_calibration_curve_list <- function(
     )
   }
 
-  calibration_curve_list$deciles_dat <- calibration_curve_list$deciles_dat |>
+  calibration_curve_list$calibration_bins_dat <- calibration_curve_list$calibration_bins_dat |>
     dplyr::mutate(
       text = glue::glue(paste0(
         hover_text_for_discrete_calibration,
@@ -335,7 +342,7 @@ create_calibration_curve_list <- function(
   calibration_curve_list$group_colors_vec <- group_colors_vec
 
   limits <- define_limits_for_calibration_plot(
-    calibration_curve_list$deciles_dat
+    calibration_curve_list$calibration_bins_dat
   )
 
   calibration_curve_list$axes_ranges <- list(xaxis = limits, yaxis = limits)
@@ -403,7 +410,7 @@ create_plotly_curve_from_calibration_curve_list <- function(
   if (type == "discrete") {
     calibration_curve <- calibration_curve |>
       plotly::add_trace(
-        data = calibration_curve_list$deciles_dat,
+        data = calibration_curve_list$calibration_bins_dat,
         type = "scatter",
         mode = "markers+lines",
         marker = list(
@@ -482,7 +489,7 @@ create_ggplot_curve_from_calibration_curve_list <- function(
 ) {
   if (type == "discrete") {
     calibration_curve <- ggplot2::ggplot(
-      calibration_curve_list$deciles_dat,
+      calibration_curve_list$calibration_bins_dat,
       ggplot2::aes(
         x = x,
         y = y,
@@ -582,10 +589,25 @@ create_ggplot_curve_from_calibration_curve_list <- function(
 }
 
 
-make_deciles_dat <- function(probs, reals) {
+make_calibration_bins_dat <- function(
+  probs,
+  reals,
+  n_bins = 10
+) {
+  if (
+    !is.numeric(n_bins) ||
+      length(n_bins) != 1L ||
+      is.na(n_bins) ||
+      !is.finite(n_bins) ||
+      n_bins <= 0 ||
+      (n_bins %% 1 != 0)
+  ) {
+    stop("`n_bins` must be a single positive whole number.", call. = FALSE)
+  }
+
   if (length(unique(probs)) == 1) {
     tibble::tibble(
-      quintile = 1,
+      bin = 1,
       x = unique(probs),
       y = mean(reals),
       sum_reals = sum(reals),
@@ -593,8 +615,8 @@ make_deciles_dat <- function(probs, reals) {
     )
   } else {
     data.frame(probs, reals) |>
-      dplyr::mutate(quintile = dplyr::ntile(probs, 10)) |>
-      dplyr::group_by(quintile) |>
+      dplyr::mutate(bin = dplyr::ntile(probs, n_bins)) |>
+      dplyr::group_by(bin) |>
       dplyr::summarise(
         y = sum(reals) / n(),
         x = mean(probs),

--- a/R/calibration_v2.R
+++ b/R/calibration_v2.R
@@ -2,8 +2,7 @@
 #'
 #' Adapt already-computed calibration curve data plus explicit semantic
 #' evaluation metadata into the canonical rtichoke_viz v2 contract. This
-#' helper does not calculate calibration statistics and is not wired into
-#' production rendering.
+#' helper does not calculate calibration statistics.
 #'
 #' @param calibration_curve_list Output from [create_calibration_curve_list()].
 #' @param evaluation_metadata Output from [build_evaluation_metadata()].
@@ -35,7 +34,7 @@ rtichoke_viz_calibration_v2_spec <- function(
   }
 
   calibration_data <- if (method == "discrete") {
-    calibration_curve_list$deciles_dat
+    calibration_curve_list$calibration_bins_dat
   } else {
     calibration_curve_list$smooth_dat
   }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -855,19 +855,6 @@ extract_reference_groups_from_performance_data <- function(
 }
 
 
-make_deciles_dat_new <- function(probs, reals) {
-  data.frame(probs, reals) |>
-    dplyr::mutate(quintile = dplyr::ntile(probs, 10)) |>
-    dplyr::group_by(quintile) |>
-    dplyr::summarise(
-      y = sum(reals) / n(),
-      x = mean(probs),
-      sum_reals = sum(reals),
-      total_obs = n()
-    ) |>
-    dplyr::ungroup()
-}
-
 create_reference_group_color_vector <- function(
   reference_groups,
   perf_dat_type,

--- a/R/rtichoke_viz.R
+++ b/R/rtichoke_viz.R
@@ -44,24 +44,24 @@ rtichoke_viz_roc_spec <- function(performance_data) {
 }
 
 rtichoke_viz_calibration_spec <- function(calibration_curve_list) {
-  deciles_dat <- calibration_curve_list$deciles_dat
+  calibration_bins_dat <- calibration_curve_list$calibration_bins_dat
   histogram <- calibration_curve_list$histogram_for_calibration
 
-  required_decile_columns <- c(
+  required_calibration_bin_columns <- c(
     "reference_group",
     "x",
     "y",
     "sum_reals",
     "total_obs"
   )
-  missing_decile_columns <- setdiff(
-    required_decile_columns,
-    names(deciles_dat)
+  missing_calibration_bin_columns <- setdiff(
+    required_calibration_bin_columns,
+    names(calibration_bins_dat)
   )
-  if (length(missing_decile_columns) > 0) {
+  if (length(missing_calibration_bin_columns) > 0) {
     stop(
       "Calibration data is missing columns: ",
-      paste(missing_decile_columns, collapse = ", "),
+      paste(missing_calibration_bin_columns, collapse = ", "),
       call. = FALSE
     )
   }
@@ -83,14 +83,14 @@ rtichoke_viz_calibration_spec <- function(calibration_curve_list) {
     )
   }
 
-  data <- lapply(seq_len(nrow(deciles_dat)), function(i) {
+  data <- lapply(seq_len(nrow(calibration_bins_dat)), function(i) {
     list(
-      model = as.character(deciles_dat$reference_group[[i]]),
-      predicted = deciles_dat$x[[i]],
-      observed = deciles_dat$y[[i]],
+      model = as.character(calibration_bins_dat$reference_group[[i]]),
+      predicted = calibration_bins_dat$x[[i]],
+      observed = calibration_bins_dat$y[[i]],
       method = "discrete",
-      events = deciles_dat$sum_reals[[i]],
-      total = deciles_dat$total_obs[[i]]
+      events = calibration_bins_dat$sum_reals[[i]],
+      total = calibration_bins_dat$total_obs[[i]]
     )
   })
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -25,7 +25,7 @@ knitr::opts_chunk$set(
 **`rtichoke`** provides interactive and static visualizations for evaluating binary prediction models. It allows data scientists and clinical researchers to seamlessly analyze performance metrics, including:
 
 * **Discrimination:** Receiver Operating Characteristic (ROC), Precision-Recall (PR), Gains, and Lift curves.
-* **Calibration:** Calibration curves with decile and smooth (lowess) representations.
+* **Calibration:** Calibration curves with binned calibration (10 rank-based/equal-frequency bins by default) and smooth (lowess) representations.
 * **Clinical Utility:** Decision Curves and Interventions Avoided.
 * **Performance Tables & Reports:** Interactive metric summaries and complete HTML reports.
 

--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ including:
 
 - **Discrimination:** Receiver Operating Characteristic (ROC),
   Precision-Recall (PR), Gains, and Lift curves.
-- **Calibration:** Calibration curves with decile and smooth (lowess)
-  representations.
+- **Calibration:** Calibration curves with binned calibration (10 rank-based/equal-frequency bins by default) and smooth (lowess) representations.
 - **Clinical Utility:** Decision Curves and Interventions Avoided.
 - **Performance Tables & Reports:** Interactive metric summaries and
   complete HTML reports.

--- a/inst/llms.txt
+++ b/inst/llms.txt
@@ -38,9 +38,9 @@ Pipeline:
 ### 3. Calibration
 - `create_calibration_curve(probs, reals, type = "discrete", ...)`
   - Compares predicted risk vs observed outcome frequency ($y = x$ diagonal is perfect calibration).
-  - `type`: `"discrete"` (binned deciles) or `"smooth"` (lowess curve).
+  - `type`: `"discrete"` (binned calibration) or `"smooth"` (lowess curve).
 - `create_calibration_curve_list(probs, reals, ...)`
-  - Returns raw calibration list components (deciles, smooth data, histogram).
+  - Returns raw calibration list components (binned calibration data, smooth data, histogram).
 
 ### 4. Clinical Utility
 - `create_decision_curve(probs, reals, ...)` / `plot_decision_curve(performance_data, ...)`

--- a/man/create_calibration_curve.Rd
+++ b/man/create_calibration_curve.Rd
@@ -12,8 +12,8 @@ create_calibration_curve(
     "#FE5F55", "#54494B", "#006E90", "#BC96E6", "#52050A", "#1F271B", "#BE7C4D",
     "#63768D", "#08A045", "#320A28", "#82FF9E", "#2176FF", "#D1603D", "#585123"),
   type = "discrete",
-  n_bins = 10,
-  size = NULL
+  size = NULL,
+  n_bins = 10
 )
 }
 \arguments{
@@ -29,9 +29,9 @@ plots}
 
 \item{type}{discrete or smooth}
 
-\item{n_bins}{Number of calibration bins for binned calibration (default 10).}
-
 \item{size}{the size of the curve}
+
+\item{n_bins}{Number of calibration bins for binned calibration (default 10).}
 }
 \description{
 Create a Calibration Curve

--- a/man/create_calibration_curve.Rd
+++ b/man/create_calibration_curve.Rd
@@ -12,6 +12,7 @@ create_calibration_curve(
     "#FE5F55", "#54494B", "#006E90", "#BC96E6", "#52050A", "#1F271B", "#BE7C4D",
     "#63768D", "#08A045", "#320A28", "#82FF9E", "#2176FF", "#D1603D", "#585123"),
   type = "discrete",
+  n_bins = 10,
   size = NULL
 )
 }
@@ -27,6 +28,8 @@ plots}
 \item{color_values}{color palette}
 
 \item{type}{discrete or smooth}
+
+\item{n_bins}{Number of calibration bins for binned calibration (default 10).}
 
 \item{size}{the size of the curve}
 }

--- a/man/create_calibration_curve_list.Rd
+++ b/man/create_calibration_curve_list.Rd
@@ -10,8 +10,8 @@ create_calibration_curve_list(
   color_values = c("#1b9e77", "#d95f02", "#7570b3", "#e7298a", "#07004D", "#E6AB02",
     "#FE5F55", "#54494B", "#006E90", "#BC96E6", "#52050A", "#1F271B", "#BE7C4D",
     "#63768D", "#08A045", "#320A28", "#82FF9E", "#2176FF", "#D1603D", "#585123"),
-  n_bins = 10,
-  size = NULL
+  size = NULL,
+  n_bins = 10
 )
 }
 \arguments{
@@ -22,9 +22,9 @@ create_calibration_curve_list(
 
 \item{color_values}{color palette}
 
-\item{n_bins}{Number of calibration bins for binned calibration (default 10).}
-
 \item{size}{the size of the curve}
+
+\item{n_bins}{Number of calibration bins for binned calibration (default 10).}
 }
 \description{
 Create a Calibration Curve List

--- a/man/create_calibration_curve_list.Rd
+++ b/man/create_calibration_curve_list.Rd
@@ -10,6 +10,7 @@ create_calibration_curve_list(
   color_values = c("#1b9e77", "#d95f02", "#7570b3", "#e7298a", "#07004D", "#E6AB02",
     "#FE5F55", "#54494B", "#006E90", "#BC96E6", "#52050A", "#1F271B", "#BE7C4D",
     "#63768D", "#08A045", "#320A28", "#82FF9E", "#2176FF", "#D1603D", "#585123"),
+  n_bins = 10,
   size = NULL
 )
 }
@@ -20,6 +21,8 @@ create_calibration_curve_list(
 \item{reals}{a list of vectors of binary outcomes (one for each population)}
 
 \item{color_values}{color palette}
+
+\item{n_bins}{Number of calibration bins for binned calibration (default 10).}
 
 \item{size}{the size of the curve}
 }

--- a/man/define_limits_for_calibration_plot.Rd
+++ b/man/define_limits_for_calibration_plot.Rd
@@ -4,19 +4,19 @@
 \alias{define_limits_for_calibration_plot}
 \title{Define limits for Calibration Curve}
 \usage{
-define_limits_for_calibration_plot(deciles_dat)
+define_limits_for_calibration_plot(calibration_bins_dat)
 }
 \arguments{
-\item{deciles_dat}{A data frame containing decile-level calibration data.}
+\item{calibration_bins_dat}{A data frame containing bin-level calibration data.}
 }
 \description{
 Define limits for Calibration Curve
 }
 \examples{
 \dontrun{
-make_deciles_dat(
+make_calibration_bins_dat(
   probs = example_dat$estimated_probabilities,
-  real = example_dat$outcome
+  reals = example_dat$outcome
 ) |>
   define_limits_for_calibration_plot()
 }

--- a/pkgdown/llms.txt
+++ b/pkgdown/llms.txt
@@ -38,9 +38,9 @@ Pipeline:
 ### 3. Calibration
 - `create_calibration_curve(probs, reals, type = "discrete", ...)`
   - Compares predicted risk vs observed outcome frequency ($y = x$ diagonal is perfect calibration).
-  - `type`: `"discrete"` (binned deciles) or `"smooth"` (lowess curve).
+  - `type`: `"discrete"` (binned calibration) or `"smooth"` (lowess curve).
 - `create_calibration_curve_list(probs, reals, ...)`
-  - Returns raw calibration list components (deciles, smooth data, histogram).
+  - Returns raw calibration list components (binned calibration data, smooth data, histogram).
 
 ### 4. Clinical Utility
 - `create_decision_curve(probs, reals, ...)` / `plot_decision_curve(performance_data, ...)`

--- a/tests/testthat/_snaps/regression-snapshots.md
+++ b/tests/testthat/_snaps/regression-snapshots.md
@@ -473,7 +473,7 @@
         "names": {
           "type": "character",
           "attributes": {},
-          "value": ["quintile", "y", "x", "sum_reals", "total_obs"]
+          "value": ["bin", "y", "x", "sum_reals", "total_obs"]
         }
       },
       "value": [

--- a/tests/testthat/test-calibration-v2.R
+++ b/tests/testthat/test-calibration-v2.R
@@ -34,7 +34,7 @@ calibration_v2_fixture <- function(groups = "Model A") {
     })
   )
   list(
-    deciles_dat = deciles,
+    calibration_bins_dat = deciles,
     smooth_dat = smooth,
     histogram_for_calibration = histogram
   )
@@ -173,10 +173,10 @@ test_that("distribution rows retain series ownership", {
 
 test_that("calibration statistics are passed through without recomputation", {
   calibration <- calibration_v2_fixture()
-  calibration$deciles_dat$x <- c(0.123456, 0.876543)
-  calibration$deciles_dat$y <- c(0.234567, 0.765432)
-  calibration$deciles_dat$sum_reals <- c(3, 17)
-  calibration$deciles_dat$total_obs <- c(19, 23)
+  calibration$calibration_bins_dat$x <- c(0.123456, 0.876543)
+  calibration$calibration_bins_dat$y <- c(0.234567, 0.765432)
+  calibration$calibration_bins_dat$sum_reals <- c(3, 17)
+  calibration$calibration_bins_dat$total_obs <- c(19, 23)
 
   spec <- rtichoke:::rtichoke_viz_calibration_v2_spec(
     calibration,
@@ -185,19 +185,19 @@ test_that("calibration statistics are passed through without recomputation", {
 
   expect_identical(
     vapply(spec$data, `[[`, 0, "predicted"),
-    calibration$deciles_dat$x
+    calibration$calibration_bins_dat$x
   )
   expect_identical(
     vapply(spec$data, `[[`, 0, "observed"),
-    calibration$deciles_dat$y
+    calibration$calibration_bins_dat$y
   )
   expect_identical(
     vapply(spec$data, `[[`, 0, "events"),
-    as.numeric(calibration$deciles_dat$sum_reals)
+    as.numeric(calibration$calibration_bins_dat$sum_reals)
   )
   expect_identical(
     vapply(spec$data, `[[`, 0, "total"),
-    as.numeric(calibration$deciles_dat$total_obs)
+    as.numeric(calibration$calibration_bins_dat$total_obs)
   )
 })
 

--- a/tests/testthat/test-calibration.R
+++ b/tests/testthat/test-calibration.R
@@ -1,27 +1,290 @@
-test_that("test deciles dat", {
-  deciles_dat <- rtichoke:::make_deciles_dat(
+test_that("make_calibration_bins_dat default n_bins = 10 numerical behavior unchanged", {
+  calibration_bins_dat <- rtichoke:::make_calibration_bins_dat(
     probs = example_dat$estimated_probabilities,
-    real = example_dat$outcome
+    reals = example_dat$outcome,
+    n_bins = 10
   )
 
-  expect_identical(deciles_dat$quintile, 1:10)
+  expect_identical(calibration_bins_dat$bin, 1:10)
   expect_identical(
-    names(deciles_dat),
-    c("quintile", "y", "x", "sum_reals", "total_obs")
+    names(calibration_bins_dat),
+    c("bin", "y", "x", "sum_reals", "total_obs")
   )
+  expect_equal(nrow(calibration_bins_dat), 10)
+  expect_equal(sum(calibration_bins_dat$total_obs), length(example_dat$outcome))
+  expect_equal(sum(calibration_bins_dat$sum_reals), sum(example_dat$outcome))
 })
 
-
 test_that("limits of calibration curve", {
-  limits_calibration_curve <- rtichoke:::make_deciles_dat(
+  limits_calibration_curve <- rtichoke:::make_calibration_bins_dat(
     probs = example_dat$estimated_probabilities,
-    real = example_dat$outcome
+    reals = example_dat$outcome
   ) |>
     rtichoke:::define_limits_for_calibration_plot()
 
   expect_equal(length(limits_calibration_curve), 2)
 })
 
+test_that("calibration validates n_bins input", {
+  probs <- example_dat$estimated_probabilities
+  reals <- example_dat$outcome
+
+  invalid_n_bins <- list(
+    NULL,
+    NA,
+    NaN,
+    Inf,
+    -1,
+    0,
+    2.5,
+    c(5, 10),
+    "10",
+    TRUE
+  )
+
+  for (val in invalid_n_bins) {
+    expect_error(
+      rtichoke:::make_calibration_bins_dat(probs, reals, n_bins = val),
+      "`n_bins` must be a single positive whole number.",
+      fixed = TRUE
+    )
+  }
+
+  # Valid integer / numeric
+  expect_no_error(rtichoke:::make_calibration_bins_dat(probs, reals, n_bins = 5L))
+  expect_no_error(rtichoke:::make_calibration_bins_dat(probs, reals, n_bins = 5))
+})
+
+test_that("n_bins validation occurs before all-identical shortcut", {
+  probs_identical <- rep(0.5, 10)
+  reals <- rep(c(0, 1), 5)
+
+  expect_error(
+    rtichoke:::make_calibration_bins_dat(probs_identical, reals, n_bins = -2),
+    "`n_bins` must be a single positive whole number.",
+    fixed = TRUE
+  )
+})
+
+test_that("n_bins = 8, n_bins = 1, n_bins > n, n = 5/11/12 with n_bins = 10", {
+  probs_100 <- seq(0.01, 1, length.out = 100)
+  reals_100 <- rep(c(0, 1), 50)
+
+  # n_bins = 8
+  dat_8 <- rtichoke:::make_calibration_bins_dat(probs_100, reals_100, n_bins = 8)
+  expect_equal(nrow(dat_8), 8)
+  expect_identical(dat_8$bin, 1:8)
+
+  # n_bins = 1
+  dat_1 <- rtichoke:::make_calibration_bins_dat(probs_100, reals_100, n_bins = 1)
+  expect_equal(nrow(dat_1), 1)
+  expect_identical(dat_1$bin, 1L)
+  expect_equal(dat_1$x, mean(probs_100))
+  expect_equal(dat_1$y, mean(reals_100))
+
+  # n = 11, n_bins = 10
+  probs_11 <- seq(0.1, 0.9, length.out = 11)
+  reals_11 <- c(0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
+  dat_11 <- rtichoke:::make_calibration_bins_dat(probs_11, reals_11, n_bins = 10)
+  expect_equal(nrow(dat_11), 10)
+  expect_equal(sum(dat_11$total_obs), 11)
+
+  # n = 12, n_bins = 10
+  probs_12 <- seq(0.1, 0.9, length.out = 12)
+  reals_12 <- c(0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
+  dat_12 <- rtichoke:::make_calibration_bins_dat(probs_12, reals_12, n_bins = 10)
+  expect_equal(nrow(dat_12), 10)
+  expect_equal(sum(dat_12$total_obs), 12)
+
+  # n = 5, n_bins = 10
+  probs_5 <- c(0.1, 0.3, 0.5, 0.7, 0.9)
+  reals_5 <- c(0, 0, 1, 1, 1)
+  dat_5 <- rtichoke:::make_calibration_bins_dat(probs_5, reals_5, n_bins = 10)
+  expect_equal(nrow(dat_5), 5)
+  expect_equal(sum(dat_5$total_obs), 5)
+  expect_false(any(dat_5$total_obs == 0)) # No empty bins materialized
+
+  # n_bins > n (n = 5, n_bins = 20)
+  dat_gt_n <- rtichoke:::make_calibration_bins_dat(probs_5, reals_5, n_bins = 20)
+  expect_equal(nrow(dat_gt_n), 5)
+  expect_equal(sum(dat_gt_n$total_obs), 5)
+  expect_false(any(dat_gt_n$total_obs == 0))
+})
+
+test_that("all probabilities identical produces one aggregate bin", {
+  probs <- rep(0.42, 20)
+  reals <- c(rep(0, 15), rep(1, 5))
+
+  dat <- rtichoke:::make_calibration_bins_dat(probs, reals, n_bins = 10)
+  expect_equal(nrow(dat), 1)
+  expect_identical(dat$bin, 1)
+  expect_equal(dat$x, 0.42)
+  expect_equal(dat$y, 0.25)
+  expect_equal(dat$sum_reals, 5)
+  expect_equal(dat$total_obs, 20)
+})
+
+test_that("partial ties crossing a bin boundary are handled correctly", {
+  probs <- c(0.1, 0.2, 0.2, 0.2, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95)
+  reals <- c(0,   0,   1,   0,   1,   1,   0,   1,   1,   1)
+
+  dat <- rtichoke:::make_calibration_bins_dat(probs, reals, n_bins = 5)
+  expect_equal(sum(dat$total_obs), 10)
+  expect_equal(sum(dat$sum_reals), sum(reals))
+  expect_identical(dat$bin, 1:5)
+})
+
+test_that("create_calibration_curve and list with multiple models and populations", {
+  # Multiple models
+  probs_models <- list(
+    "Model 1" = example_dat$estimated_probabilities,
+    "Model 2" = example_dat$random_guess
+  )
+  reals_models <- list(example_dat$outcome)
+
+  curve_list_m <- create_calibration_curve_list(
+    probs = probs_models,
+    reals = reals_models,
+    n_bins = 8
+  )
+  expect_equal(nrow(curve_list_m$calibration_bins_dat), 16)
+  expect_setequal(
+    unique(curve_list_m$calibration_bins_dat$reference_group),
+    c("Model 1", "Model 2")
+  )
+
+  # Multiple populations
+  probs_pops <- list(
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |> dplyr::pull(estimated_probabilities),
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |> dplyr::pull(estimated_probabilities)
+  )
+  reals_pops <- list(
+    "train" = example_dat |> dplyr::filter(type_of_set == "train") |> dplyr::pull(outcome),
+    "test" = example_dat |> dplyr::filter(type_of_set == "test") |> dplyr::pull(outcome)
+  )
+
+  curve_list_p <- create_calibration_curve_list(
+    probs = probs_pops,
+    reals = reals_pops,
+    n_bins = 6
+  )
+  expect_equal(nrow(curve_list_p$calibration_bins_dat), 12)
+  expect_setequal(
+    unique(curve_list_p$calibration_bins_dat$reference_group),
+    c("train", "test")
+  )
+})
+
+test_that("reference_group identity remains unchanged", {
+  curve_list <- create_calibration_curve_list(
+    probs = list("Model A" = example_dat$estimated_probabilities),
+    reals = list(example_dat$outcome),
+    n_bins = 5
+  )
+  expect_identical(
+    unique(curve_list$calibration_bins_dat$reference_group),
+    "Model A"
+  )
+  expect_identical(
+    unique(curve_list$reference_data$reference_group),
+    "reference_line"
+  )
+})
+
+test_that("smooth output unaffected by non-default n_bins in create_calibration_curve", {
+  probs <- list(example_dat$estimated_probabilities)
+  reals <- list(example_dat$outcome)
+
+  curve_smooth_def <- create_calibration_curve(
+    probs = probs,
+    reals = reals,
+    type = "smooth",
+    n_bins = 10,
+    interactive = FALSE
+  )
+
+  curve_smooth_custom <- create_calibration_curve(
+    probs = probs,
+    reals = reals,
+    type = "smooth",
+    n_bins = 5,
+    interactive = FALSE
+  )
+
+  # Compare ggplot output / axes limits / structure
+  expect_equal(
+    curve_smooth_def$patches$plots[[1]]$coordinates$limits,
+    curve_smooth_custom$patches$plots[[1]]$coordinates$limits
+  )
+})
+
+test_that("Plotly discrete rendering works with n_bins", {
+  plotly_curve <- create_calibration_curve(
+    probs = list(example_dat$estimated_probabilities),
+    reals = list(example_dat$outcome),
+    type = "discrete",
+    n_bins = 8,
+    interactive = TRUE
+  )
+  expect_s3_class(plotly_curve, "plotly")
+})
+
+test_that("ggplot discrete rendering works with n_bins", {
+  gg_curve <- create_calibration_curve(
+    probs = list(example_dat$estimated_probabilities),
+    reals = list(example_dat$outcome),
+    type = "discrete",
+    n_bins = 8,
+    interactive = FALSE
+  )
+  expect_s3_class(gg_curve, "patchwork")
+})
+
+test_that("canonical v1 and v2 adapters consume calibration_bins_dat", {
+  curve_list <- create_calibration_curve_list(
+    probs = list("Model A" = example_dat$estimated_probabilities),
+    reals = list(example_dat$outcome),
+    n_bins = 8
+  )
+
+  v1_spec <- rtichoke:::rtichoke_viz_calibration_spec(curve_list)
+  expect_equal(v1_spec$schemaVersion, "1.0")
+  expect_equal(length(v1_spec$data), 8)
+
+  metadata <- rtichoke:::build_evaluation_metadata(
+    probs = list("Model A" = example_dat$estimated_probabilities),
+    reals = list(example_dat$outcome)
+  )
+
+  v2_spec <- rtichoke:::rtichoke_viz_calibration_v2_spec(
+    curve_list,
+    metadata,
+    method = "discrete"
+  )
+  expect_equal(v2_spec$schemaVersion, "2.0")
+  expect_equal(length(v2_spec$data), 8)
+  # Ensure CalibrationSpec does not contain n_bins or bin
+  expect_false("n_bins" %in% names(v2_spec$data[[1]]))
+  expect_false("bin" %in% names(v2_spec$data[[1]]))
+})
+
+test_that("browser summary report path succeeds with calibration_bins_dat", {
+  probs <- list("Model A" = example_dat$estimated_probabilities)
+  reals <- list(example_dat$outcome)
+  metadata <- rtichoke:::build_evaluation_metadata(probs, reals)
+  curve_list <- create_calibration_curve_list(probs, reals, n_bins = 10)
+
+  calib_v2 <- rtichoke:::rtichoke_viz_calibration_v2_spec(
+    curve_list,
+    metadata,
+    method = "discrete"
+  )
+  report_spec <- rtichoke:::rtichoke_viz_report_spec(calib_v2)
+  browser_tag <- rtichoke:::render_rtichoke_viz_report_browser(report_spec)
+
+  expect_s3_class(browser_tag, "shiny.tag.list")
+  expect_match(as.character(browser_tag), "renderReport", fixed = TRUE)
+})
 
 test_that("calibration validates probability and outcome inputs", {
   expect_error(
@@ -36,29 +299,6 @@ test_that("calibration validates probability and outcome inputs", {
     create_calibration_curve(
       probs = list(example_dat$estimated_probabilities),
       reals = list(replace(example_dat$outcome, 1, 2))
-    ),
-    "Outcomes are out of the range"
-  )
-
-  expect_error(
-    create_calibration_curve_list(
-      probs = list(
-        train = example_dat |>
-          dplyr::filter(type_of_set == "train") |>
-          dplyr::pull(estimated_probabilities),
-        test = example_dat |>
-          dplyr::filter(type_of_set == "test") |>
-          dplyr::pull(estimated_probabilities)
-      ),
-      reals = list(
-        train = example_dat |>
-          dplyr::filter(type_of_set == "train") |>
-          dplyr::pull(outcome),
-        test = example_dat |>
-          dplyr::filter(type_of_set == "test") |>
-          dplyr::pull(outcome) |>
-          replace(1, 2)
-      )
     ),
     "Outcomes are out of the range"
   )

--- a/tests/testthat/test-calibration.R
+++ b/tests/testthat/test-calibration.R
@@ -51,8 +51,16 @@ test_that("calibration validates n_bins input", {
   }
 
   # Valid integer / numeric
-  expect_no_error(rtichoke:::make_calibration_bins_dat(probs, reals, n_bins = 5L))
-  expect_no_error(rtichoke:::make_calibration_bins_dat(probs, reals, n_bins = 5))
+  expect_no_error(rtichoke:::make_calibration_bins_dat(
+    probs,
+    reals,
+    n_bins = 5L
+  ))
+  expect_no_error(rtichoke:::make_calibration_bins_dat(
+    probs,
+    reals,
+    n_bins = 5
+  ))
 })
 
 test_that("n_bins validation occurs before all-identical shortcut", {
@@ -71,12 +79,20 @@ test_that("n_bins = 8, n_bins = 1, n_bins > n, n = 5/11/12 with n_bins = 10", {
   reals_100 <- rep(c(0, 1), 50)
 
   # n_bins = 8
-  dat_8 <- rtichoke:::make_calibration_bins_dat(probs_100, reals_100, n_bins = 8)
+  dat_8 <- rtichoke:::make_calibration_bins_dat(
+    probs_100,
+    reals_100,
+    n_bins = 8
+  )
   expect_equal(nrow(dat_8), 8)
   expect_identical(dat_8$bin, 1:8)
 
   # n_bins = 1
-  dat_1 <- rtichoke:::make_calibration_bins_dat(probs_100, reals_100, n_bins = 1)
+  dat_1 <- rtichoke:::make_calibration_bins_dat(
+    probs_100,
+    reals_100,
+    n_bins = 1
+  )
   expect_equal(nrow(dat_1), 1)
   expect_identical(dat_1$bin, 1L)
   expect_equal(dat_1$x, mean(probs_100))
@@ -85,14 +101,22 @@ test_that("n_bins = 8, n_bins = 1, n_bins > n, n = 5/11/12 with n_bins = 10", {
   # n = 11, n_bins = 10
   probs_11 <- seq(0.1, 0.9, length.out = 11)
   reals_11 <- c(0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
-  dat_11 <- rtichoke:::make_calibration_bins_dat(probs_11, reals_11, n_bins = 10)
+  dat_11 <- rtichoke:::make_calibration_bins_dat(
+    probs_11,
+    reals_11,
+    n_bins = 10
+  )
   expect_equal(nrow(dat_11), 10)
   expect_equal(sum(dat_11$total_obs), 11)
 
   # n = 12, n_bins = 10
   probs_12 <- seq(0.1, 0.9, length.out = 12)
   reals_12 <- c(0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
-  dat_12 <- rtichoke:::make_calibration_bins_dat(probs_12, reals_12, n_bins = 10)
+  dat_12 <- rtichoke:::make_calibration_bins_dat(
+    probs_12,
+    reals_12,
+    n_bins = 10
+  )
   expect_equal(nrow(dat_12), 10)
   expect_equal(sum(dat_12$total_obs), 12)
 
@@ -105,7 +129,11 @@ test_that("n_bins = 8, n_bins = 1, n_bins > n, n = 5/11/12 with n_bins = 10", {
   expect_false(any(dat_5$total_obs == 0)) # No empty bins materialized
 
   # n_bins > n (n = 5, n_bins = 20)
-  dat_gt_n <- rtichoke:::make_calibration_bins_dat(probs_5, reals_5, n_bins = 20)
+  dat_gt_n <- rtichoke:::make_calibration_bins_dat(
+    probs_5,
+    reals_5,
+    n_bins = 20
+  )
   expect_equal(nrow(dat_gt_n), 5)
   expect_equal(sum(dat_gt_n$total_obs), 5)
   expect_false(any(dat_gt_n$total_obs == 0))
@@ -126,7 +154,7 @@ test_that("all probabilities identical produces one aggregate bin", {
 
 test_that("partial ties crossing a bin boundary are handled correctly", {
   probs <- c(0.1, 0.2, 0.2, 0.2, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95)
-  reals <- c(0,   0,   1,   0,   1,   1,   0,   1,   1,   1)
+  reals <- c(0, 0, 1, 0, 1, 1, 0, 1, 1, 1)
 
   dat <- rtichoke:::make_calibration_bins_dat(probs, reals, n_bins = 5)
   expect_equal(sum(dat$total_obs), 10)
@@ -155,12 +183,20 @@ test_that("create_calibration_curve and list with multiple models and population
 
   # Multiple populations
   probs_pops <- list(
-    "train" = example_dat |> dplyr::filter(type_of_set == "train") |> dplyr::pull(estimated_probabilities),
-    "test" = example_dat |> dplyr::filter(type_of_set == "test") |> dplyr::pull(estimated_probabilities)
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
+      dplyr::pull(estimated_probabilities),
+    "test" = example_dat |>
+      dplyr::filter(type_of_set == "test") |>
+      dplyr::pull(estimated_probabilities)
   )
   reals_pops <- list(
-    "train" = example_dat |> dplyr::filter(type_of_set == "train") |> dplyr::pull(outcome),
-    "test" = example_dat |> dplyr::filter(type_of_set == "test") |> dplyr::pull(outcome)
+    "train" = example_dat |>
+      dplyr::filter(type_of_set == "train") |>
+      dplyr::pull(outcome),
+    "test" = example_dat |>
+      dplyr::filter(type_of_set == "test") |>
+      dplyr::pull(outcome)
   )
 
   curve_list_p <- create_calibration_curve_list(

--- a/tests/testthat/test-calibration.R
+++ b/tests/testthat/test-calibration.R
@@ -5,6 +5,7 @@ test_that("make_calibration_bins_dat default n_bins = 10 numerical behavior unch
     n_bins = 10
   )
 
+  expect_type(calibration_bins_dat$bin, "integer")
   expect_identical(calibration_bins_dat$bin, 1:10)
   expect_identical(
     names(calibration_bins_dat),
@@ -48,6 +49,26 @@ test_that("calibration validates n_bins input", {
       "`n_bins` must be a single positive whole number.",
       fixed = TRUE
     )
+    expect_error(
+      create_calibration_curve(
+        probs = list(probs),
+        reals = list(reals),
+        type = "discrete",
+        n_bins = val
+      ),
+      "`n_bins` must be a single positive whole number.",
+      fixed = TRUE
+    )
+    expect_error(
+      create_calibration_curve(
+        probs = list(probs),
+        reals = list(reals),
+        type = "smooth",
+        n_bins = val
+      ),
+      "`n_bins` must be a single positive whole number.",
+      fixed = TRUE
+    )
   }
 
   # Valid integer / numeric
@@ -74,7 +95,7 @@ test_that("n_bins validation occurs before all-identical shortcut", {
   )
 })
 
-test_that("n_bins = 8, n_bins = 1, n_bins > n, n = 5/11/12 with n_bins = 10", {
+test_that("n_bins parity assertions: N=12 B=10 and N=5 B=10", {
   probs_100 <- seq(0.01, 1, length.out = 100)
   reals_100 <- rep(c(0, 1), 50)
 
@@ -109,7 +130,7 @@ test_that("n_bins = 8, n_bins = 1, n_bins > n, n = 5/11/12 with n_bins = 10", {
   expect_equal(nrow(dat_11), 10)
   expect_equal(sum(dat_11$total_obs), 11)
 
-  # n = 12, n_bins = 10
+  # n = 12, n_bins = 10 strengthened parity assertion
   probs_12 <- seq(0.1, 0.9, length.out = 12)
   reals_12 <- c(0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1)
   dat_12 <- rtichoke:::make_calibration_bins_dat(
@@ -118,13 +139,14 @@ test_that("n_bins = 8, n_bins = 1, n_bins > n, n = 5/11/12 with n_bins = 10", {
     n_bins = 10
   )
   expect_equal(nrow(dat_12), 10)
-  expect_equal(sum(dat_12$total_obs), 12)
+  expect_equal(dat_12$total_obs, c(2, 2, 1, 1, 1, 1, 1, 1, 1, 1))
 
-  # n = 5, n_bins = 10
+  # n = 5, n_bins = 10 strengthened parity assertion
   probs_5 <- c(0.1, 0.3, 0.5, 0.7, 0.9)
   reals_5 <- c(0, 0, 1, 1, 1)
   dat_5 <- rtichoke:::make_calibration_bins_dat(probs_5, reals_5, n_bins = 10)
   expect_equal(nrow(dat_5), 5)
+  expect_identical(dat_5$bin, 1:5) # occupied bin labels equal 1:5
   expect_equal(sum(dat_5$total_obs), 5)
   expect_false(any(dat_5$total_obs == 0)) # No empty bins materialized
 
@@ -135,17 +157,19 @@ test_that("n_bins = 8, n_bins = 1, n_bins > n, n = 5/11/12 with n_bins = 10", {
     n_bins = 20
   )
   expect_equal(nrow(dat_gt_n), 5)
+  expect_identical(dat_gt_n$bin, 1:5)
   expect_equal(sum(dat_gt_n$total_obs), 5)
   expect_false(any(dat_gt_n$total_obs == 0))
 })
 
-test_that("all probabilities identical produces one aggregate bin", {
+test_that("all probabilities identical produces one aggregate bin with integer bin column", {
   probs <- rep(0.42, 20)
   reals <- c(rep(0, 15), rep(1, 5))
 
   dat <- rtichoke:::make_calibration_bins_dat(probs, reals, n_bins = 10)
   expect_equal(nrow(dat), 1)
-  expect_identical(dat$bin, 1)
+  expect_type(dat$bin, "integer")
+  expect_identical(dat$bin, 1L)
   expect_equal(dat$x, 0.42)
   expect_equal(dat$y, 0.25)
   expect_equal(dat$sum_reals, 5)
@@ -162,8 +186,51 @@ test_that("partial ties crossing a bin boundary are handled correctly", {
   expect_identical(dat$bin, 1:5)
 })
 
+test_that("positional argument order preserves size compatibility", {
+  colors <- c(
+    "#1b9e77",
+    "#d95f02",
+    "#7570b3",
+    "#e7298a",
+    "#07004D",
+    "#E6AB02",
+    "#FE5F55",
+    "#54494B",
+    "#006E90",
+    "#BC96E6",
+    "#52050A",
+    "#1F271B",
+    "#BE7C4D",
+    "#63768D",
+    "#08A045",
+    "#320A28",
+    "#82FF9E",
+    "#2176FF",
+    "#D1603D",
+    "#585123"
+  )
+
+  # Positional 6th argument 'size = 300'
+  curve_list_pos <- create_calibration_curve_list(
+    list(example_dat$estimated_probabilities),
+    list(example_dat$outcome),
+    colors,
+    300
+  )
+  expect_equal(curve_list_pos$size[[1]], 300)
+
+  curve_pos <- create_calibration_curve(
+    list(example_dat$estimated_probabilities),
+    list(example_dat$outcome),
+    TRUE,
+    colors,
+    "discrete",
+    300
+  )
+  expect_s3_class(curve_pos, "plotly")
+})
+
 test_that("create_calibration_curve and list with multiple models and populations", {
-  # Multiple models
   probs_models <- list(
     "Model 1" = example_dat$estimated_probabilities,
     "Model 2" = example_dat$random_guess
@@ -181,7 +248,6 @@ test_that("create_calibration_curve and list with multiple models and population
     c("Model 1", "Model 2")
   )
 
-  # Multiple populations
   probs_pops <- list(
     "train" = example_dat |>
       dplyr::filter(type_of_set == "train") |>
@@ -247,7 +313,6 @@ test_that("smooth output unaffected by non-default n_bins in create_calibration_
     interactive = FALSE
   )
 
-  # Compare ggplot output / axes limits / structure
   expect_equal(
     curve_smooth_def$patches$plots[[1]]$coordinates$limits,
     curve_smooth_custom$patches$plots[[1]]$coordinates$limits
@@ -299,7 +364,6 @@ test_that("canonical v1 and v2 adapters consume calibration_bins_dat", {
   )
   expect_equal(v2_spec$schemaVersion, "2.0")
   expect_equal(length(v2_spec$data), 8)
-  # Ensure CalibrationSpec does not contain n_bins or bin
   expect_false("n_bins" %in% names(v2_spec$data[[1]]))
   expect_false("bin" %in% names(v2_spec$data[[1]]))
 })
@@ -335,6 +399,29 @@ test_that("calibration validates probability and outcome inputs", {
     create_calibration_curve(
       probs = list(example_dat$estimated_probabilities),
       reals = list(replace(example_dat$outcome, 1, 2))
+    ),
+    "Outcomes are out of the range"
+  )
+
+  expect_error(
+    create_calibration_curve_list(
+      probs = list(
+        train = example_dat |>
+          dplyr::filter(type_of_set == "train") |>
+          dplyr::pull(estimated_probabilities),
+        test = example_dat |>
+          dplyr::filter(type_of_set == "test") |>
+          dplyr::pull(estimated_probabilities)
+      ),
+      reals = list(
+        train = example_dat |>
+          dplyr::filter(type_of_set == "train") |>
+          dplyr::pull(outcome),
+        test = example_dat |>
+          dplyr::filter(type_of_set == "test") |>
+          dplyr::pull(outcome) |>
+          replace(1, 2)
+      )
     ),
     "Outcomes are out of the range"
   )

--- a/tests/testthat/test-regression-snapshots.R
+++ b/tests/testthat/test-regression-snapshots.R
@@ -86,10 +86,11 @@ test_that("ppcr stratification stays stable", {
 
 
 test_that("calibration deciles stay stable", {
-  deciles_dat <- rtichoke:::make_deciles_dat(
+  calibration_bins_dat <- rtichoke:::make_calibration_bins_dat(
     probs = example_dat$estimated_probabilities,
-    real = example_dat$outcome
+    reals = example_dat$outcome,
+    n_bins = 10
   )
 
-  expect_snapshot_value(deciles_dat, style = "json2")
+  expect_snapshot_value(calibration_bins_dat, style = "json2")
 })

--- a/tests/testthat/test-report-browser.R
+++ b/tests/testthat/test-report-browser.R
@@ -5,7 +5,7 @@ report_browser_specs <- function() {
   metadata <- rtichoke:::build_evaluation_metadata(probs, reals)
 
   calibration_curve_list <- list(
-    deciles_dat = data.frame(
+    calibration_bins_dat = data.frame(
       reference_group = "Model A",
       x = c(0.2, 0.8),
       y = c(0.25, 0.75),

--- a/tests/testthat/test-rtichoke-viz.R
+++ b/tests/testthat/test-rtichoke-viz.R
@@ -57,7 +57,7 @@ test_that("real calibration output maps to the canonical viz spec", {
   expect_identical(spec$y, "observed")
   expect_length(
     spec$data,
-    nrow(calibration_curve_list$deciles_dat)
+    nrow(calibration_curve_list$calibration_bins_dat)
   )
   expect_length(
     spec$distribution,
@@ -68,9 +68,9 @@ test_that("real calibration output maps to the canonical viz spec", {
     c("Estimated model", "Random guess")
   )
 
-  first_decile <- calibration_curve_list$deciles_dat[1, ]
-  expect_identical(spec$data[[1]]$predicted, first_decile$x[[1]])
-  expect_identical(spec$data[[1]]$observed, first_decile$y[[1]])
-  expect_identical(spec$data[[1]]$events, first_decile$sum_reals[[1]])
-  expect_identical(spec$data[[1]]$total, first_decile$total_obs[[1]])
+  first_bin <- calibration_curve_list$calibration_bins_dat[1, ]
+  expect_identical(spec$data[[1]]$predicted, first_bin$x[[1]])
+  expect_identical(spec$data[[1]]$observed, first_bin$y[[1]])
+  expect_identical(spec$data[[1]]$events, first_bin$sum_reals[[1]])
+  expect_identical(spec$data[[1]]$total, first_bin$total_obs[[1]])
 })

--- a/tests/testthat/test-semantic-characterization.R
+++ b/tests/testthat/test-semantic-characterization.R
@@ -229,7 +229,7 @@ test_that("calibration keeps grouping and one global identity line", {
 
   expect_identical(multi_model$performance_type, "several models")
   expect_setequal(
-    unique(multi_model$deciles_dat$reference_group),
+    unique(multi_model$calibration_bins_dat$reference_group),
     c("Model A", "Model B")
   )
   expect_identical(
@@ -250,7 +250,7 @@ test_that("calibration keeps grouping and one global identity line", {
 
   expect_identical(multi_population$performance_type, "several populations")
   expect_setequal(
-    unique(multi_population$deciles_dat$reference_group),
+    unique(multi_population$calibration_bins_dat$reference_group),
     c("Population low", "Population high")
   )
   expect_identical(

--- a/vignettes/calibration.Rmd
+++ b/vignettes/calibration.Rmd
@@ -44,9 +44,9 @@ The 45-degree diagonal line ($y = x$) represents perfect calibration. Points abo
 
 ## Calibration Curve Options
 
-`rtichoke` supports both binned (deciles) and smooth non-parametric (lowess) representations for calibration analysis:
+`rtichoke` supports both binned calibration (10 rank-based/equal-frequency bins by default) and smooth non-parametric (lowess) representations for calibration analysis:
 
-- **Deciles (Binned):** Divides predictions into equal-sized subgroups and plots observed proportion vs. mean prediction in each bin.
+- **Binned Calibration:** Divides predictions into rank-based equal-frequency bins and plots observed proportion vs. mean prediction in each bin.
 - **Smooth (Lowess):** Fits a non-parametric smoother across the full range of predicted probabilities.
 
 ---

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 `rtichoke` is an R package for interactive and static evaluation of binary prediction models. It allows analysts and clinical researchers to inspect model performance across multiple complementary dimensions:
 
 - **Discrimination:** ROC, Precision-Recall, Gains, and Lift curves.
-- **Calibration:** Binned (decile) and smooth (lowess) calibration curves.
+- **Calibration:** Binned calibration (10 rank-based/equal-frequency bins by default) and smooth (lowess) calibration curves.
 - **Clinical Utility:** Decision Curves and Interventions Avoided.
 - **Performance Tables & Reports:** Interactive tables and automated HTML reports.
 

--- a/vignettes/recipes-and-workflows.Rmd
+++ b/vignettes/recipes-and-workflows.Rmd
@@ -144,7 +144,7 @@ create_summary_report(
 | **Lift Curve** | Yes | `probs = list(...)`, `reals = list(...)` |
 | **Decision Curve (Net Benefit)** | Yes | `probs = list(...)`, `reals = list(...)` |
 | **Interventions Avoided** | Yes | Integrated in Decision Curve outputs |
-| **Calibration Curve** | Yes | Deciles / Smooth options available |
+| **Calibration Curve** | Yes | Binned calibration (10 rank-based bins by default) / Smooth options available |
 | **Performance Tables** | Yes | Threshold-specific metrics summary |
 | **HTML Summary Report** | Yes | `create_summary_report()` |
 | **Time-Dependent Horizons (`_times`)** | No | Not implemented in R package |


### PR DESCRIPTION
Completed implementation of calibration-bin abstraction.

* Starting SHA: `d801627149668331794fcc04d9e1d3d992753226`
* Public API:
  * `create_calibration_curve(..., type = "discrete", n_bins = 10)`
  * `create_calibration_curve_list(..., n_bins = 10)`
* Internal terminology:
  * `n_bins`
  * `bin`
  * `calibration_bins_dat`
  * `make_calibration_bins_dat()`
* Confirmation: Default remains 10; numerical default behavior is unchanged.
* Test / Check results: All 752 testthat tests pass; R CMD check passes with 0 errors and 0 warnings.

---
*PR created automatically by Jules for task [13251023715797704745](https://jules.google.com/task/13251023715797704745) started by @uriahf*