### PR TITLE
feat: add producer-owned rank_bins to prepare_probs_distribution_data

### DIFF
--- a/R/prepare_probs_distribution_data.R
+++ b/R/prepare_probs_distribution_data.R
@@ -1,16 +1,21 @@
 #' Prepare Prediction Distribution Data
 #'
-#' Internal helper to prepare exact prediction distribution score intervals (`bins`)
+#' Internal helper to prepare exact prediction distribution score intervals (`bins`),
+#' producer-owned probability-quantile rank bins (`rank_bins`),
 #' and operating points (`operating_points`) for static binary outcomes. Reuses production
 #' `prepare_performance_data()` as the authoritative source for cutoff grids and metrics.
 #'
 #' @inheritParams prepare_performance_data
 #'
-#' @return A named list with two tidy tibbles:
+#' @return A named list with three tidy tibbles:
 #'   \item{bins}{Exact score intervals covering score space 0 to 1. Includes zero-score
 #'     interval `[0, 0]` and right-closed intervals `(lower, upper]` aligned to effective
 #'     cutoffs. Columns: `evaluation`, `model`, `population`, `lower`, `upper`,
 #'     `include_lower`, `include_upper`, `n_positive`, `n_negative`.}
+#'   \item{rank_bins}{Producer-owned probability-quantile rank bins derived directly from
+#'     individual probabilities and outcomes using `assign_probability_quantile_strata()`.
+#'     Columns: `evaluation`, `model`, `population`, `rank_lower`, `rank_upper`,
+#'     `n_positive`, `n_negative`.}
 #'   \item{operating_points}{Selectable operating points. Columns: `evaluation`,
 #'     `model`, `population`, `type`, `value` (requested metric value), `cutoff`
 #'     (effective score cutoff), `realized_ppcr` (actual predicted positives fraction).}
@@ -188,12 +193,46 @@ prepare_probs_distribution_data <- function(
           "n_negative"
         )
 
-      list(bins = bins, operating_points = operating_points)
+      # 3. Rank Bins table
+      strata <- assign_probability_quantile_strata(probabilities, by)
+      q <- as.integer(round(1 / by))
+      rank_upper <- round(seq(by, 1.0, length.out = q), 10)
+      rank_lower <- c(0.0, rank_upper[-q])
+
+      obs_strata_df <- tibble::tibble(
+        stratum = strata,
+        outcome = outcomes
+      )
+
+      stratum_counts <- obs_strata_df |>
+        dplyr::group_by(stratum = .data$stratum, .drop = FALSE) |>
+        dplyr::summarise(
+          n_positive = as.integer(sum(.data$outcome == 1)),
+          n_negative = as.integer(sum(.data$outcome == 0)),
+          .groups = "drop"
+        )
+
+      rank_bins <- tibble::tibble(
+        evaluation = current_evaluation_metadata$evaluation,
+        model = current_evaluation_metadata$model,
+        population = current_evaluation_metadata$population,
+        rank_lower = rank_lower,
+        rank_upper = rank_upper,
+        n_positive = stratum_counts$n_positive,
+        n_negative = stratum_counts$n_negative
+      )
+
+      list(
+        bins = bins,
+        rank_bins = rank_bins,
+        operating_points = operating_points
+      )
     }
   )
 
   list(
     bins = dplyr::bind_rows(purrr::map(evaluation_results, "bins")),
+    rank_bins = dplyr::bind_rows(purrr::map(evaluation_results, "rank_bins")),
     operating_points = dplyr::bind_rows(purrr::map(
       evaluation_results,
       "operating_points"

--- a/man/prepare_probs_distribution_data.Rd
+++ b/man/prepare_probs_distribution_data.Rd
@@ -23,17 +23,22 @@ prepare_probs_distribution_data(
 Threshold or alternatively by Predicted Positives Condition Rate}
 }
 \value{
-A named list with two tidy tibbles:
+A named list with three tidy tibbles:
 \item{bins}{Exact score intervals covering score space 0 to 1. Includes zero-score
 interval \verb{[0, 0]} and right-closed intervals \verb{(lower, upper]} aligned to effective
 cutoffs. Columns: \code{evaluation}, \code{model}, \code{population}, \code{lower}, \code{upper},
 \code{include_lower}, \code{include_upper}, \code{n_positive}, \code{n_negative}.}
+\item{rank_bins}{Producer-owned probability-quantile rank bins derived directly from
+individual probabilities and outcomes using \code{assign_probability_quantile_strata()}.
+Columns: \code{evaluation}, \code{model}, \code{population}, \code{rank_lower}, \code{rank_upper},
+\code{n_positive}, \code{n_negative}.}
 \item{operating_points}{Selectable operating points. Columns: \code{evaluation},
 \code{model}, \code{population}, \code{type}, \code{value} (requested metric value), \code{cutoff}
 (effective score cutoff), \code{realized_ppcr} (actual predicted positives fraction).}
 }
 \description{
-Internal helper to prepare exact prediction distribution score intervals (\code{bins})
+Internal helper to prepare exact prediction distribution score intervals (\code{bins}),
+producer-owned probability-quantile rank bins (\code{rank_bins}),
 and operating points (\code{operating_points}) for static binary outcomes. Reuses production
 \code{prepare_performance_data()} as the authoritative source for cutoff grids and metrics.
 }

--- a/tests/testthat/test-prepare_probs_distribution_data.R
+++ b/tests/testthat/test-prepare_probs_distribution_data.R
@@ -525,7 +525,15 @@ test_that("rank_bins output schema and mass conservation for continuous predicti
 
   expect_equal(
     names(rb),
-    c("evaluation", "model", "population", "rank_lower", "rank_upper", "n_positive", "n_negative")
+    c(
+      "evaluation",
+      "model",
+      "population",
+      "rank_lower",
+      "rank_upper",
+      "n_positive",
+      "n_negative"
+    )
   )
   expect_equal(nrow(rb), 5L)
   expect_equal(rb$rank_lower, c(0.0, 0.2, 0.4, 0.6, 0.8))
@@ -542,8 +550,18 @@ test_that("rank_bins stratification-invariance across probability_threshold and 
   r <- list(c(0, 0, 1, 0, 1, 1))
   by <- 0.2
 
-  res_thresh <- prepare_probs_distribution_data(p, r, by = by, stratified_by = "probability_threshold")
-  res_ppcr <- prepare_probs_distribution_data(p, r, by = by, stratified_by = "ppcr")
+  res_thresh <- prepare_probs_distribution_data(
+    p,
+    r,
+    by = by,
+    stratified_by = "probability_threshold"
+  )
+  res_ppcr <- prepare_probs_distribution_data(
+    p,
+    r,
+    by = by,
+    stratified_by = "ppcr"
+  )
 
   expect_identical(res_thresh$rank_bins, res_ppcr$rank_bins)
 })
@@ -602,15 +620,56 @@ test_that("backward-compatibility: existing bins and operating_points outputs re
   r <- list(GOLDEN_THRESHOLD_OUTCOMES)
   by <- 0.1
 
-  res_thresh <- prepare_probs_distribution_data(p, r, by = by, stratified_by = "probability_threshold")
-  res_ppcr <- prepare_probs_distribution_data(p, r, by = by, stratified_by = "ppcr")
+  res_thresh <- prepare_probs_distribution_data(
+    p,
+    r,
+    by = by,
+    stratified_by = "probability_threshold"
+  )
+  res_ppcr <- prepare_probs_distribution_data(
+    p,
+    r,
+    by = by,
+    stratified_by = "ppcr"
+  )
 
   # Existing outputs must be identical to pre-rankBins assertions
-  expect_equal(names(res_thresh$bins), c("evaluation", "model", "population", "lower", "upper", "include_lower", "include_upper", "n_positive", "n_negative"))
-  expect_equal(names(res_thresh$operating_points), c("evaluation", "model", "population", "type", "value", "cutoff", "realized_ppcr"))
+  expect_equal(
+    names(res_thresh$bins),
+    c(
+      "evaluation",
+      "model",
+      "population",
+      "lower",
+      "upper",
+      "include_lower",
+      "include_upper",
+      "n_positive",
+      "n_negative"
+    )
+  )
+  expect_equal(
+    names(res_thresh$operating_points),
+    c(
+      "evaluation",
+      "model",
+      "population",
+      "type",
+      "value",
+      "cutoff",
+      "realized_ppcr"
+    )
+  )
 
   target_cutoffs <- c(0.0, 0.2, 0.5, 1.0)
-  sub_ops <- dplyr::filter(res_thresh$operating_points, .data$cutoff %in% target_cutoffs)
+  sub_ops <- dplyr::filter(
+    res_thresh$operating_points,
+    .data$cutoff %in% target_cutoffs
+  )
   expect_equal(sub_ops$cutoff, target_cutoffs)
-  expect_equal(sub_ops$realized_ppcr, c(1.0, 2 / 3, 1 / 3, 0.0), tolerance = 1e-5)
+  expect_equal(
+    sub_ops$realized_ppcr,
+    c(1.0, 2 / 3, 1 / 3, 0.0),
+    tolerance = 1e-5
+  )
 })

--- a/tests/testthat/test-prepare_probs_distribution_data.R
+++ b/tests/testthat/test-prepare_probs_distribution_data.R
@@ -513,6 +513,85 @@ test_that("input validation stops on invalid probabilities or arguments", {
 # PRODUCER-OWNED rank_bins STATISTICAL CONTRACT & INVARIANCE TESTS
 # -----------------------------------------------------------------------------
 
+test_that("primary golden fixture matches exact statistical rank_bins table", {
+  # INDEPENDENT PRIMARY GOLDEN FIXTURE (N = 9, by = 0.20)
+  p <- list(c(0.00, 0.15, 0.30, 0.50, 0.50, 0.50, 0.65, 0.80, 1.00))
+  r <- list(c(0, 1, 0, 1, 0, 1, 1, 0, 1))
+  by <- 0.20
+
+  res <- prepare_probs_distribution_data(p, r, by = by)
+
+  expect_true("rank_bins" %in% names(res))
+  rb <- res$rank_bins
+
+  expect_equal(
+    names(rb),
+    c(
+      "evaluation",
+      "model",
+      "population",
+      "rank_lower",
+      "rank_upper",
+      "n_positive",
+      "n_negative"
+    )
+  )
+  expect_equal(nrow(rb), 5L)
+  expect_equal(rb$rank_lower, c(0.0, 0.2, 0.4, 0.6, 0.8))
+  expect_equal(rb$rank_upper, c(0.2, 0.4, 0.6, 0.8, 1.0))
+
+  # Assert complete exact table, including empty [0.4, 0.6] stratum
+  expect_equal(rb$n_positive, c(1L, 2L, 0L, 1L, 1L))
+  expect_equal(rb$n_negative, c(1L, 2L, 0L, 0L, 1L))
+
+  # Mass conservation
+  expect_equal(sum(rb$n_positive), 5L)
+  expect_equal(sum(rb$n_negative), 4L)
+  expect_equal(sum(rb$n_positive + rb$n_negative), 9L)
+})
+
+test_that("secondary golden fixture N < q matches exact statistical rank_bins table", {
+  # INDEPENDENT SECONDARY GOLDEN FIXTURE (N = 3, by = 0.20)
+  p <- list(c(0.10, 0.50, 0.90))
+  r <- list(c(0, 1, 1))
+  by <- 0.20
+
+  res <- prepare_probs_distribution_data(p, r, by = by)
+  rb <- res$rank_bins
+
+  expect_equal(nrow(rb), 5L)
+  expect_equal(rb$rank_lower, c(0.0, 0.2, 0.4, 0.6, 0.8))
+  expect_equal(rb$rank_upper, c(0.2, 0.4, 0.6, 0.8, 1.0))
+
+  # Assert complete table including both empty strata [0.2, 0.4] and [0.6, 0.8]
+  expect_equal(rb$n_positive, c(0L, 0L, 1L, 0L, 1L))
+  expect_equal(rb$n_negative, c(1L, 0L, 0L, 0L, 0L))
+
+  # Mass conservation
+  expect_equal(sum(rb$n_positive), 2L)
+  expect_equal(sum(rb$n_negative), 1L)
+  expect_equal(sum(rb$n_positive + rb$n_negative), 3L)
+})
+
+test_that("rank_bins demonstrates row permutation order invariance including tied score group", {
+  # Primary fixture with observation permutation permuting score=0.50 tied group
+  p <- c(0.00, 0.15, 0.30, 0.50, 0.50, 0.50, 0.65, 0.80, 1.00)
+  r <- c(0, 1, 0, 1, 0, 1, 1, 0, 1)
+  by <- 0.20
+
+  res_orig <- prepare_probs_distribution_data(list(p), list(r), by = by)
+
+  # Reorder rows: shuffle tied group (indices 4, 5, 6 -> 5, 4, 6) and other elements
+  perm_idx <- c(5, 1, 9, 4, 6, 2, 7, 3, 8)
+  res_perm <- prepare_probs_distribution_data(
+    list(p[perm_idx]),
+    list(r[perm_idx]),
+    by = by
+  )
+
+  expect_identical(res_orig$rank_bins, res_perm$rank_bins)
+})
+
 test_that("rank_bins output schema and mass conservation for continuous predictions", {
   p <- list(c(0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.95))
   r <- list(c(0, 1, 0, 1, 0, 1, 0, 1, 0, 1))
@@ -567,7 +646,7 @@ test_that("rank_bins stratification-invariance across probability_threshold and 
 })
 
 test_that("rank_bins handles ties, repeated boundaries, empty strata, and zero/one scores", {
-  # Deterministic fixture exercising ties, 0, 1, repeated cutoffs, empty strata, and N < num_strata
+  # Deterministic fixture exercising ties, 0, 1, repeated cutoffs, empty strata
   p <- list(c(0.0, 0.1, 0.1, 0.1, 0.5, 0.9, 1.0))
   r <- list(c(0, 1, 0, 1, 1, 0, 1))
   by <- 0.2
@@ -599,20 +678,6 @@ test_that("rank_bins handles ties, repeated boundaries, empty strata, and zero/o
   expect_equal(sum(rb$n_positive), 4L)
   expect_equal(sum(rb$n_negative), 3L)
   expect_equal(sum(rb$n_positive + rb$n_negative), 7L)
-})
-
-test_that("rank_bins preserves grid when N < number of strata", {
-  p <- list(c(0.2, 0.8))
-  r <- list(c(0, 1))
-  by <- 0.2 # 5 strata requested for 2 observations
-
-  res <- prepare_probs_distribution_data(p, r, by = by)
-  rb <- res$rank_bins
-
-  expect_equal(nrow(rb), 5L)
-  expect_equal(sum(rb$n_positive), 1L)
-  expect_equal(sum(rb$n_negative), 1L)
-  expect_equal(sum(rb$n_positive + rb$n_negative), 2L)
 })
 
 test_that("backward-compatibility: existing bins and operating_points outputs remain unchanged", {

--- a/tests/testthat/test-prepare_probs_distribution_data.R
+++ b/tests/testthat/test-prepare_probs_distribution_data.R
@@ -507,3 +507,110 @@ test_that("input validation stops on invalid probabilities or arguments", {
     "'arg' should be one of"
   )
 })
+
+
+# -----------------------------------------------------------------------------
+# PRODUCER-OWNED rank_bins STATISTICAL CONTRACT & INVARIANCE TESTS
+# -----------------------------------------------------------------------------
+
+test_that("rank_bins output schema and mass conservation for continuous predictions", {
+  p <- list(c(0.05, 0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85, 0.95))
+  r <- list(c(0, 1, 0, 1, 0, 1, 0, 1, 0, 1))
+  by <- 0.2
+
+  res <- prepare_probs_distribution_data(p, r, by = by)
+
+  expect_true("rank_bins" %in% names(res))
+  rb <- res$rank_bins
+
+  expect_equal(
+    names(rb),
+    c("evaluation", "model", "population", "rank_lower", "rank_upper", "n_positive", "n_negative")
+  )
+  expect_equal(nrow(rb), 5L)
+  expect_equal(rb$rank_lower, c(0.0, 0.2, 0.4, 0.6, 0.8))
+  expect_equal(rb$rank_upper, c(0.2, 0.4, 0.6, 0.8, 1.0))
+
+  # Mass conservation
+  expect_equal(sum(rb$n_positive), sum(r[[1]] == 1))
+  expect_equal(sum(rb$n_negative), sum(r[[1]] == 0))
+  expect_equal(sum(rb$n_positive + rb$n_negative), length(p[[1]]))
+})
+
+test_that("rank_bins stratification-invariance across probability_threshold and ppcr modes", {
+  p <- list(c(0.1, 0.2, 0.5, 0.5, 0.8, 0.9))
+  r <- list(c(0, 0, 1, 0, 1, 1))
+  by <- 0.2
+
+  res_thresh <- prepare_probs_distribution_data(p, r, by = by, stratified_by = "probability_threshold")
+  res_ppcr <- prepare_probs_distribution_data(p, r, by = by, stratified_by = "ppcr")
+
+  expect_identical(res_thresh$rank_bins, res_ppcr$rank_bins)
+})
+
+test_that("rank_bins handles ties, repeated boundaries, empty strata, and zero/one scores", {
+  # Deterministic fixture exercising ties, 0, 1, repeated cutoffs, empty strata, and N < num_strata
+  p <- list(c(0.0, 0.1, 0.1, 0.1, 0.5, 0.9, 1.0))
+  r <- list(c(0, 1, 0, 1, 1, 0, 1))
+  by <- 0.2
+
+  res <- prepare_probs_distribution_data(p, r, by = by)
+  rb <- res$rank_bins
+
+  # Complete requested grid retained (5 strata for by = 0.2)
+  expect_equal(nrow(rb), 5L)
+  expect_equal(rb$rank_lower, c(0.0, 0.2, 0.4, 0.6, 0.8))
+  expect_equal(rb$rank_upper, c(0.2, 0.4, 0.6, 0.8, 1.0))
+
+  # Strata 2 (0.2-0.4) and 3 (0.4-0.6) receive 0 observations due to repeated quantile boundary
+  expect_equal(rb$n_positive[2], 0L)
+  expect_equal(rb$n_negative[2], 0L)
+  expect_equal(rb$n_positive[3], 0L)
+  expect_equal(rb$n_negative[3], 0L)
+
+  # Identical scores 0.1 are all assigned to stratum 1 (0.0-0.2) and never split
+  expect_equal(rb$n_positive[1], 2L)
+  expect_equal(rb$n_negative[1], 2L)
+
+  # Exact score 0.0 is assigned to stratum 1
+  # Exact score 1.0 is assigned to stratum 5 (0.8-1.0)
+  expect_equal(rb$n_positive[5], 1L)
+  expect_equal(rb$n_negative[5], 1L)
+
+  # Mass conservation
+  expect_equal(sum(rb$n_positive), 4L)
+  expect_equal(sum(rb$n_negative), 3L)
+  expect_equal(sum(rb$n_positive + rb$n_negative), 7L)
+})
+
+test_that("rank_bins preserves grid when N < number of strata", {
+  p <- list(c(0.2, 0.8))
+  r <- list(c(0, 1))
+  by <- 0.2 # 5 strata requested for 2 observations
+
+  res <- prepare_probs_distribution_data(p, r, by = by)
+  rb <- res$rank_bins
+
+  expect_equal(nrow(rb), 5L)
+  expect_equal(sum(rb$n_positive), 1L)
+  expect_equal(sum(rb$n_negative), 1L)
+  expect_equal(sum(rb$n_positive + rb$n_negative), 2L)
+})
+
+test_that("backward-compatibility: existing bins and operating_points outputs remain unchanged", {
+  p <- list(GOLDEN_THRESHOLD_SCORES)
+  r <- list(GOLDEN_THRESHOLD_OUTCOMES)
+  by <- 0.1
+
+  res_thresh <- prepare_probs_distribution_data(p, r, by = by, stratified_by = "probability_threshold")
+  res_ppcr <- prepare_probs_distribution_data(p, r, by = by, stratified_by = "ppcr")
+
+  # Existing outputs must be identical to pre-rankBins assertions
+  expect_equal(names(res_thresh$bins), c("evaluation", "model", "population", "lower", "upper", "include_lower", "include_upper", "n_positive", "n_negative"))
+  expect_equal(names(res_thresh$operating_points), c("evaluation", "model", "population", "type", "value", "cutoff", "realized_ppcr"))
+
+  target_cutoffs <- c(0.0, 0.2, 0.5, 1.0)
+  sub_ops <- dplyr::filter(res_thresh$operating_points, .data$cutoff %in% target_cutoffs)
+  expect_equal(sub_ops$cutoff, target_cutoffs)
+  expect_equal(sub_ops$realized_ppcr, c(1.0, 2 / 3, 1 / 3, 0.0), tolerance = 1e-5)
+})


### PR DESCRIPTION
Implement producer-owned prediction distribution rank_bins in R prepare_probs_distribution_data().

---
*PR created automatically by Jules for task [16109305510772387551](https://jules.google.com/task/16109305510772387551) started by @uriahf*